### PR TITLE
Fix for chained responses with newlines

### DIFF
--- a/ipfsApi/encoding.py
+++ b/ipfsApi/encoding.py
@@ -42,6 +42,8 @@ class Json(Encoding):
         results.append(obj)
         cur = idx
         while cur < len(json_string) - 1:
+            if json_string[cur] == '\n':
+                cur += 1
             obj, idx = self.decoder.raw_decode(json_string[cur:])
             results.append(obj)
             cur += idx

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -25,6 +25,15 @@ class TestEncoding(unittest.TestCase):
         self.assertEqual(res[0]['key1'], 'value1')
         self.assertEqual(res[1]['key2'], 'value2')
 
+    def test_json_parse_chained_newlines(self):
+        data1 = {'key1': 'value1'}
+        data2 = {'key2': 'value2'}
+        res = self.encoder.parse(
+            json.dumps(data1) + '\n' + json.dumps(data2))
+        self.assertEqual(len(res), 2)
+        self.assertEqual(res[0]['key1'], 'value1')
+        self.assertEqual(res[1]['key2'], 'value2')
+
     def test_json_encode(self):
         data = {'key': 'value'}
         self.assertEqual(


### PR DESCRIPTION
This fixes the JSON decoder to handle chained responses which have newlines between the objects, such as for `api.ping(...)`.