### PR TITLE
Fix TravisCI and make compatible with go-ipfs v0.4.3rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+before_script:
+  - eval "$(gimme 1.6)"
+  - mkdir $HOME/go
+  - export GOPATH="$HOME/go"
+  - export PATH="$PATH:$GOPATH/bin"
+  - echo $GOPATH
+  - echo $PATH
+  - go get -d github.com/ipfs/go-ipfs
+  - pushd . && cd $GOPATH/src/github.com/ipfs/go-ipfs && make install && popd
 install:
   - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"
 script:
+  - ipfs init
+  - ipfs daemon &
   - tox -e pep8
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+matrix:
+  include:
+  - python: "2.7"
+    env: TOXENV=py27
+  - python: "3.3"
+    env: TOXENV=py33
+  - python: "3.4"
+    env: TOXENV=py34
+  - python: "3.5"
+    env: TOXENV=py35
 before_script:
-  - eval "$(gimme 1.6)"
-  - mkdir $HOME/go
-  - export GOPATH="$HOME/go"
-  - export PATH="$PATH:$GOPATH/bin"
-  - echo $GOPATH
-  - echo $PATH
-  - go get -d github.com/ipfs/go-ipfs
-  - pushd . && cd $GOPATH/src/github.com/ipfs/go-ipfs && make install && popd
+  - wget "https://dist.ipfs.io/go-ipfs/v0.4.3-rc2/go-ipfs_v0.4.3-rc2_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
+  - mkdir $HOME/bin
+  - pushd . && cd $HOME/bin && tar -xzvf /tmp/ipfs.tar.gz && popd
+  - export PATH="$HOME/bin/go-ipfs:$PATH"
 install:
   - "pip install -r requirements.txt"
   - "pip install -r test-requirements.txt"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 Check out [ipfs](http://ipfs.io/) and [the API command reference](http://ipfs.io/docs/commands/) for more information about the IPFS API.
 
+*Note:* This library constantly has to change to stay compatible with the IPFS HTTP API.
+Currently, this library is tested against [go-ipfs v0.4.3rc2](https://github.com/ipfs/go-ipfs/releases/tag/v0.4.3-rc2).
+You may experience compatibility issues when attempting to use it with other versions of go-ipfs.
+
 ## Table of Contents
 
 - [Install](#install)

--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -986,7 +986,7 @@ class Client(object):
         body, headers = multipart.stream_text(string,
                                               chunk_size=chunk_size)
         return self._client.request('/add', data=body,
-                                    headers=headers, **kwargs)[1]
+                                    headers=headers, **kwargs)
 
     def add_json(self, json_obj, **kwargs):
         """Adds a json-serializable Python dict as a json file to IPFS.

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -36,33 +36,27 @@ class IpfsApiTest(unittest.TestCase):
 
     ## test_add_multiple_from_list
     fake_file  = 'fake_dir/fsdfgh'
-    fake_file_only_res = [{'Name': 'fsdfgh', 'Bytes': 8},
-            {'Name': 'fsdfgh', 'Hash': 'QmQcCtMgLVwvMQGu6mvsRYLjwqrZJcYtH4mboM9urWW9vX'}]
+    fake_file_only_res = {'Name': 'fsdfgh',
+                          'Hash': 'QmQcCtMgLVwvMQGu6mvsRYLjwqrZJcYtH4mboM9urWW9vX'}
     fake_file2 = 'fake_dir/popoiopiu'
-    fake_files_res = [{'Name': 'fsdfgh', 'Bytes': 8},
+    fake_files_res = [
             {'Name': 'fsdfgh', 'Hash': 'QmQcCtMgLVwvMQGu6mvsRYLjwqrZJcYtH4mboM9urWW9vX'},
-            {'Name': 'popoiopiu', 'Bytes': 15},
             {'Name': 'popoiopiu', 'Hash': 'QmYAhvKYu46rh5NcHzeu6Bhc7NG9SqkF9wySj2jvB74Rkv'}]
 
     ## test_add_multiple_from_dirname
     fake_dir_test2 = 'fake_dir/test2'
-    fake_dir_res = [{'Name': 'test2/fssdf', 'Bytes': 14},
+    fake_dir_res = [
             {'Name': 'test2/fssdf', 'Hash': 'Qmb1NPqPzdHCMvHRfCkk6TWLcnpGJ71KnafacCMm6TKLcD'},
-            {'Name': 'test2/llllg', 'Bytes': 9},
             {'Name': 'test2/llllg', 'Hash': 'QmNuvmuFeeWWpxjCQwLkHshr8iqhGLWXFzSGzafBeawTTZ'},
             {'Name': 'test2', 'Hash': 'QmX1dd5DtkgoiYRKaPQPTCtXArUu4jEZ62rJBUcd5WhxAZ'}]
 
     ## test_add_recursive
     fake_dir = 'fake_dir'
-    fake_dir_recursive_res = [{'Bytes': 8, 'Name': 'fake_dir/fsdfgh'},
+    fake_dir_recursive_res = [
             {'Hash': 'QmQcCtMgLVwvMQGu6mvsRYLjwqrZJcYtH4mboM9urWW9vX', 'Name': 'fake_dir/fsdfgh'},
-            {'Bytes': 15, 'Name': 'fake_dir/popoiopiu'},
             {'Hash': 'QmYAhvKYu46rh5NcHzeu6Bhc7NG9SqkF9wySj2jvB74Rkv', 'Name': 'fake_dir/popoiopiu'},
-            {'Bytes': 14, 'Name': 'fake_dir/test2/fssdf'},
             {'Hash': 'Qmb1NPqPzdHCMvHRfCkk6TWLcnpGJ71KnafacCMm6TKLcD', 'Name': 'fake_dir/test2/fssdf'},
-            {'Bytes': 9, 'Name': 'fake_dir/test2/llllg'},
             {'Hash': 'QmNuvmuFeeWWpxjCQwLkHshr8iqhGLWXFzSGzafBeawTTZ', 'Name': 'fake_dir/test2/llllg'},
-            {'Bytes': 8, 'Name': 'fake_dir/test3/ppppoooooooooo'},
             {'Hash': 'QmeMbJSHNCesAh7EeopackUdjutTJznum1Fn7knPm873Fe', 'Name': 'fake_dir/test3/ppppoooooooooo'},
             {'Hash': 'QmX1dd5DtkgoiYRKaPQPTCtXArUu4jEZ62rJBUcd5WhxAZ', 'Name': 'fake_dir/test2'},
             {'Hash': 'QmRphRr6ULDEj7YnXpLdnxhnPiVjv5RDtGX3er94Ec6v4Q', 'Name': 'fake_dir/test3'},


### PR DESCRIPTION
TravisCI previously ignored the functional tests that required an IPFS daemon to be running. #46 enabled those tests, but did not configure TravisCI to run an IPFS daemon. Now, Travis will download the release version of go-ipfs v0.4.3rc2 and run it before running the tests, ensuring that the functional tests pass too.

There have been some changes to the HTTP API responses since go-ipfs v0.4.3rc1, so this PR also updates the tests to reflect those changes.

This will resolve #50 