### PR TITLE
Update get function to accept destination path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov*
 .cache
 docs/build/
 .python-version
+.idea/

--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 from . import http, multipart, utils
 from .commands import ArgCommand, Command, DownloadCommand, FileCommand
 from .exceptions import ipfsApiError
+import shutil
 
 default_host = 'localhost'
 default_port = 5001
@@ -201,16 +202,21 @@ class Client(object):
         return self._add.request(self._client, (), files,
                                  recursive=recursive, **kwargs)
 
-    def get(self, multihash, **kwargs):
+    def get(self, multihash, output_path='.', **kwargs):
         """Downloads a file, or directory of files from IPFS.
 
-        Files are placed in the current working directory.
+        Files are placed in the current working directory if
+        output_path is not specified. Otherwise, they are
+        moved to output_path.
 
         Keyword arguments:
         multihash -- unique checksum used to identify IPFS resources
+        output_path -- where to put the downloaded file
         kwargs -- additional named arguments
         """
-        return self._get.request(self._client, multihash, **kwargs)
+        self._get.request(self._client, multihash, **kwargs)
+        if output_path is not '.':
+            shutil.move(multihash, output_path)
 
     def cat(self, multihash, **kwargs):
         r"""Returns the contents of a file identified by hash, as a string.

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -174,6 +174,21 @@ class IpfsApiTest(unittest.TestCase):
         os.remove(test_hash)
         self.assertNotIn(test_hash, os.listdir(os.getcwd()))
 
+    def test_get_file_with_rename(self):
+        self.api.add(self.fake_file)
+
+        test_hash = self.fake[0]['Hash']
+        local_file_name = "test_file.txt"
+
+        # Download the file and save it to the current working
+        # directory with the given name
+        self.api.get(test_hash, output_path=local_file_name)
+        self.assertIn(local_file_name, os.listdir(os.getcwd()))
+
+        self.assertTrue(local_file_name in os.listdir(os.getcwd()))
+        os.remove(local_file_name)
+        self.assertNotIn(local_file_name, os.listdir(os.getcwd()))
+
     def test_get_dir(self):
         self.api.add(self.fake_dir, recursive=True)
 
@@ -184,6 +199,17 @@ class IpfsApiTest(unittest.TestCase):
 
         shutil.rmtree(test_hash)
         self.assertNotIn(test_hash, os.listdir(os.getcwd()))
+
+    def test_get_dir_with_rename(self):
+        self.api.add(self.fake_dir, recursive=True)
+
+        test_hash = self.fake[8]['Hash']
+        local_dir_name = "test_dir"
+        self.api.get(test_hash, output_path=local_dir_name)
+        self.assertIn(local_dir_name, os.listdir(os.getcwd()))
+
+        shutil.rmtree(local_dir_name)
+        self.assertNotIn(local_dir_name, os.listdir(os.getcwd()))
 
     def test_get_path(self):
         self.api.add(self.fake_file)


### PR DESCRIPTION
Now the `api.get()` function can accept a filepath that it will move the downloaded file to. This mimics the functionality of `ipfs get <hash> -o <path>`. This PR should resolve #48 