### PR TITLE
Clean up the API client constructor and default params

### DIFF
--- a/ipfsApi/client.py
+++ b/ipfsApi/client.py
@@ -9,9 +9,9 @@ from . import http, multipart, utils
 from .commands import ArgCommand, Command, DownloadCommand, FileCommand
 from .exceptions import ipfsApiError
 
-default_host = 'localhost'
-default_port = 5001
-default_base = 'api/v0'
+DEFAULT_HOST = 'localhost'
+DEFAULT_PORT = 5001
+DEFAULT_BASE = 'api/v0'
 
 
 class Client(object):
@@ -98,15 +98,9 @@ class Client(object):
 
     _clientfactory = http.HTTPClient
 
-    def __init__(self, host=None, port=None,
-                 base=None, default_enc='json', **defaults):
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT,
+                 base=DEFAULT_BASE, default_enc='json', **defaults):
         """Connects to the API port of an IPFS node."""
-        if host is None:
-            host = default_host
-        if port is None:
-            port = default_port
-        if base is None:
-            base = default_base
 
         self._client = self._clientfactory(host, port, base,
                                            default_enc, **defaults)

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -20,7 +20,7 @@ def is_available():
     if not isinstance(__is_available, bool):
         s = socket.socket()
         try:
-            s.connect((ipfsApi.default_host, ipfsApi.default_port))
+            s.connect((ipfsApi.DEFAULT_HOST, ipfsApi.DEFAULT_PORT))
         except IOError:
             __is_available = False
         else:
@@ -39,7 +39,7 @@ def skipIfOffline():
 
 
 def test_ipfs_node_available():
-    addr = "[{0}]:{1}".format(ipfsApi.default_host, ipfsApi.default_port)
+    addr = "[{0}]:{1}".format(ipfsApi.DEFAULT_HOST, ipfsApi.DEFAULT_PORT)
     assert is_available(), "Functional tests require an IPFS node to be available at: " + addr
 
 


### PR DESCRIPTION
Use appropriate default parameters here.