### PR TITLE
sort keys when serializing objects to JSON

### DIFF
--- a/ipfsapi/encoding.py
+++ b/ipfsapi/encoding.py
@@ -277,7 +277,8 @@ class Json(Encoding):
             bytes
         """
         try:
-            result = json.dumps(obj, sort_keys=True)
+            result = json.dumps(obj, sort_keys=True, indent=None,
+                                separators=(',', ':'))
             if isinstance(result, six.text_type):
                 return result.encode("utf-8")
             else:

--- a/ipfsapi/encoding.py
+++ b/ipfsapi/encoding.py
@@ -277,7 +277,7 @@ class Json(Encoding):
             bytes
         """
         try:
-            result = json.dumps(obj)
+            result = json.dumps(obj, sort_keys=True)
             if isinstance(result, six.text_type):
                 return result.encode("utf-8")
             else:

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -225,7 +225,7 @@ class IpfsApiTest(unittest.TestCase):
         # have to test the string added to IPFS, deserializing JSON will not
         # test order of keys
         self.assertEqual(
-            '{"Action": "Open", "Name": "IPFS", "Pubkey": 7, "Type": "PR"}',
+            '{"Action":"Open","Name":"IPFS","Pubkey":7,"Type":"PR"}',
             self.api.cat(res).decode('utf-8')
         )
 

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -226,7 +226,7 @@ class IpfsApiTest(unittest.TestCase):
         # test order of keys
         self.assertEqual(
             '{"Action": "Open", "Name": "IPFS", "Pubkey": 7, "Type": "PR"}',
-            self.api.cat(res)
+            self.api.cat(res).decode('utf-8')
         )
 
     def test_add_get_pyobject(self):

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -216,6 +216,19 @@ class IpfsApiTest(unittest.TestCase):
                          sorted(res,
                                 key=lambda x: x['Name']))
 
+    def test_add_json(self):
+        data = {'Action': 'Open', 'Type': 'PR', 'Name': 'IPFS', 'Pubkey': 7}
+        res = self.api.add_json(data)
+        self.assertEqual(data,
+                         self.api.get_json(res))
+
+        # have to test the string added to IPFS, deserializing JSON will not
+        # test order of keys
+        self.assertEqual(
+            '{"Action": "Open", "Name": "IPFS", "Pubkey": 7, "Type": "PR"}',
+            self.api.cat(res)
+        )
+
     def test_add_get_pyobject(self):
         data = [-1, 3.14, u'Hän€', b'23' ]
         res = self.api.add_pyobj(data)

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -107,7 +107,7 @@ class TestEncoding(unittest.TestCase):
     def test_json_encode(self):
         """Tests serilization of json formatted string into an object."""
         data = {'key': 'value'}
-        assert self.encoder_json.encode(data) == b'{"key": "value"}'
+        assert self.encoder_json.encode(data) == b'{"key":"value"}'
 
     def test_encode_pickle(self):
         """Tests serilization of pickle formatted string into an object."""


### PR DESCRIPTION
Currently the `add_json` method doesn't sort keys before serializing a Python object to JSON.

Example script:

```
import ipfsapi
import json
from pprint import pprint


api = ipfsapi.connect('127.0.0.1', 5001)
data = """{
  "Action": 0,
  "Type": 0,
  "Name": "hiya",
  "PubKey": "tprv8ZgxMBicQKsPd1Cv3T..."
}"""
print(data)

data = json.loads(data)

ipfs_object_hash = api.add_json(data)
print("ipfs_object_hash: %s" % ipfs_object_hash)
```

Script on node1:

```
$ ./venv/bin/python t1.py
{
  "Action": 0,
  "Type": 0,
  "Name": "hiya",
  "PubKey": "tprv8ZgxMBicQKsPd1Cv3T..."
}
ipfs_object_hash: QmarCcvguM1tsyxboHKtRD8J3RA9446HKg2TnLPhevMiQd
```


Same script on node2:

```
$ ./venv/bin/python t1.py
{
  "Action": 0,
  "Type": 0,
  "Name": "hiya",
  "PubKey": "tprv8ZgxMBicQKsPd1Cv3T..."
}
ipfs_object_hash: QmPEpZ1C9jghELZh9pFAyamyd6pBXum7JBd79QasLoGp5E
```


Even though the same content was added via `add_json`, the IPFS hashes are different b/c the dict keys weren't sorted when serialized to JSON (note the keys are moved around):

```
/usr/local/bin/ipfs cat QmarCcvguM1tsyxboHKtRD8J3RA9446HKg2TnLPhevMiQd
{"Action": 0, "Type": 0, "Name": "hiya", "PubKey": "tprv8ZgxMBicQKsPd1Cv3T..."}
```

```
/usr/local/bin/ipfs cat QmPEpZ1C9jghELZh9pFAyamyd6pBXum7JBd79QasLoGp5E
{"Type": 0, "Name": "hiya", "PubKey": "tprv8ZgxMBicQKsPd1Cv3T...", "Action": 0}
```
