### PR TITLE
Add recursive and nocache options to name_resolve API call.

### DIFF
--- a/ipfsapi/client.py
+++ b/ipfsapi/client.py
@@ -848,7 +848,7 @@ class Client(object):
         return self._client.request('/name/publish', args,
                                     decoder='json', **kwargs)
 
-    def name_resolve(self, name=None, recursive=False, 
+    def name_resolve(self, name=None, recursive=False,
                      nocache=False, **kwargs):
         """Gets the value currently published at an IPNS name.
 
@@ -874,7 +874,7 @@ class Client(object):
         -------
             dict : The IPFS path the IPNS hash points at
         """
-        kwargs.setdefault("opts", {"recursive": recursive, 
+        kwargs.setdefault("opts", {"recursive": recursive,
                                    "nocache": nocache})
         args = (name,) if name is not None else ()
         return self._client.request('/name/resolve', args,

--- a/ipfsapi/client.py
+++ b/ipfsapi/client.py
@@ -848,7 +848,7 @@ class Client(object):
         return self._client.request('/name/publish', args,
                                     decoder='json', **kwargs)
 
-    def name_resolve(self, name=None, **kwargs):
+    def name_resolve(self, name=None, recursive=False, nocache=False, **kwargs):
         """Gets the value currently published at an IPNS name.
 
         IPNS is a PKI namespace, where names are the hashes of public keys, and
@@ -864,11 +864,16 @@ class Client(object):
         ----------
         name : str
             The IPNS name to resolve (defaults to the connected node)
+        recursive : bool
+            Resolve until the result is not an IPFS name (default: false)
+        nocache : bool
+            Do not use cached entries (default: false)
 
         Returns
         -------
             dict : The IPFS path the IPNS hash points at
         """
+        kwargs.setdefault("opts", {"recursive": recursive, "nocache": nocache})
         args = (name,) if name is not None else ()
         return self._client.request('/name/resolve', args,
                                     decoder='json', **kwargs)

--- a/ipfsapi/client.py
+++ b/ipfsapi/client.py
@@ -848,7 +848,8 @@ class Client(object):
         return self._client.request('/name/publish', args,
                                     decoder='json', **kwargs)
 
-    def name_resolve(self, name=None, recursive=False, nocache=False, **kwargs):
+    def name_resolve(self, name=None, recursive=False, 
+                     nocache=False, **kwargs):
         """Gets the value currently published at an IPNS name.
 
         IPNS is a PKI namespace, where names are the hashes of public keys, and
@@ -873,7 +874,8 @@ class Client(object):
         -------
             dict : The IPFS path the IPNS hash points at
         """
-        kwargs.setdefault("opts", {"recursive": recursive, "nocache": nocache})
+        kwargs.setdefault("opts", {"recursive": recursive, 
+                                   "nocache": nocache})
         args = (name,) if name is not None else ()
         return self._client.request('/name/resolve', args,
                                     decoder='json', **kwargs)


### PR DESCRIPTION
The current Python API call for IPNS name resolution (name_resolve) does not support the recursive and nocache options that are supported on the command line; this very minimal pull request adds them, with their defaults set to false (as on the command line) so that existing Python code that relies upon the current API will work without modification.