### PR TITLE
Add support and tests for several `.add()` options

### DIFF
--- a/ipfsapi/client.py
+++ b/ipfsapi/client.py
@@ -107,7 +107,7 @@ class Client(object):
 
         self._client = self._clientfactory(host, port, base, **defaults)
 
-    def add(self, files, recursive=False, pattern='**', **kwargs):
+    def add(self, files, recursive=False, pattern='**', *args, **kwargs):
         """Add a file, or directory of files to IPFS.
 
         .. code-block:: python
@@ -128,11 +128,35 @@ class Client(object):
             Single `*glob* <https://docs.python.org/3/library/glob.html>`_
             pattern or list of *glob* patterns and compiled regular expressions
             to match the names of the filepaths to keep
+        trickle : bool
+            Use trickle-dag format (optimized for streaming) when generating
+            the dag; see `the FAQ <https://github.com/ipfs/faq/issues/218>` for
+            more information (Default: ``False``)
+        only_hash : bool
+            Only chunk and hash, but do not write to disk (Default: ``False``)
+        wrap_with_directory : bool
+            Wrap files with a directory object to preserve their filename
+            (Default: ``False``)
+        chunker : str
+            The chunking algorithm to use
+        pin : bool
+            Pin this object when adding (Default: ``True``)
 
         Returns
         -------
             dict: File name and hash of the added file node
         """
+        #PY2: No support for kw-only parameters after glob parameters
+        opts = {
+            "trickle": kwargs.pop("trickle", False),
+            "only-hash": kwargs.pop("only_hash", False),
+            "wrap-with-directory": kwargs.pop("wrap_with_directory", False),
+            "pin": kwargs.pop("pin", True)
+        }
+        if "chunker" in kwargs:
+            opts["chunker"] = kwargs.pop("chunker")
+        kwargs.setdefault("opts", opts)
+
         body, headers = multipart.stream_filesystem_node(
             files, recursive, pattern, self.chunk_size
         )


### PR DESCRIPTION
This also refactors `IpfsApiTest` to use py.test `assert` and to properly clean
up pins after each test.

Fixes #84.