### PR TITLE
Fix pre-commit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ And the unit tests:
 
     $ tox
 
-You can arrange to run the pep8 tests automatically before each commit by
+You can arrange to run the code style tests automatically before each commit by
 installing a `pre-commit` hook:
 
     $ ./tools/pre-commit --install

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -16,5 +16,5 @@ if [ "x$1" = "x--install" ]; then
 	exit
 fi
 
-# run pep8 tests before accepting a commit
-tox -e pep8
+# run code style tests before accepting a commit
+tox -e codestyle


### PR DESCRIPTION
There's no `pep8` environment configured in `tox.ini`.
We should use `codestyle` instead.