### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
   - wget "https://dist.ipfs.io/go-ipfs/v0.4.10/go-ipfs_v0.4.10_linux-amd64.tar.gz" -O /tmp/ipfs.tar.gz
-  - mkdir $HOME/bin
+  - mkdir -p $HOME/bin
   - pushd . && cd $HOME/bin && tar -xzvf /tmp/ipfs.tar.gz && popd
   - export PATH="$HOME/bin/go-ipfs:$PATH"
 


### PR DESCRIPTION
In my other PR #115, Travis complains "File exists" when executing `mkdir $HOME/bin`.

I think the installation of `IPFS` should be configured in some global *before run* hook, but I haven't found such configuration in the Travis documentation yet.

So here's a quick fix.