### PR TITLE
add 'offset' and 'length' parameters to cat method

### DIFF
--- a/ipfsapi/client.py
+++ b/ipfsapi/client.py
@@ -2378,7 +2378,7 @@ class Client(object):
             ... c.pubsub_pub('testing', 'hello')
             ... for message in sub:
             ...     print(message)
-            ...     # Stop reading the subscription after 
+            ...     # Stop reading the subscription after
             ...     # we receive one publication
             ...     break
             {'from': '<base64encoded IPFS id>',

--- a/ipfsapi/client.py
+++ b/ipfsapi/client.py
@@ -201,7 +201,7 @@ class Client(object):
         args = (multihash,)
         return self._client.download('/get', args, **kwargs)
 
-    def cat(self, multihash, **kwargs):
+    def cat(self, multihash, offset=0, length=-1, **kwargs):
         r"""Retrieves the contents of a file identified by hash.
 
         .. code-block:: python
@@ -217,13 +217,22 @@ class Client(object):
         ----------
         multihash : str
             The path to the IPFS object(s) to be retrieved
+        offset : int
+            Byte offset to begin reading from
+        length : int
+            Maximum number of bytes to read(-1 for all)
 
         Returns
         -------
             str : File contents
         """
+        opts = {}
+        if offset != 0:
+            opts['offset'] = offset
+        if length != -1:
+            opts['length'] = length
         args = (multihash,)
-        return self._client.request('/cat', args, **kwargs)
+        return self._client.request('/cat', args, opts=opts, **kwargs)
 
     def ls(self, multihash, **kwargs):
         """Returns a list of objects linked to by the given hash.

--- a/ipfsapi/http.py
+++ b/ipfsapi/http.py
@@ -113,6 +113,8 @@ class StreamDecodeIterator(object):
 def stream_decode_full(response, parser):
     with StreamDecodeIterator(response, parser) as response_iter:
         result = list(response_iter)
+        if len(result) == 0:
+            return b''
         if len(result) == 1:
             return result[0]
         else:

--- a/test/functional/tests.py
+++ b/test/functional/tests.py
@@ -386,6 +386,18 @@ class IpfsApiTest(unittest.TestCase):
         finally:
             self._clean_up_pins()
 
+    def test_cat_file_block(self):
+        self.api.add(self.fake_file)
+
+        content = b"dsadsad\n"
+        try:
+            for offset in range(len(content)):
+                for length in range(len(content)):
+                    block = self.api.cat('QmQcCtMgLVwvMQGu6mvsRYLjwqrZJcYtH4mboM9urWW9vX', offset=offset, length=length)
+                    assert block == content[offset:offset+length]
+        finally:
+            self._clean_up_pins()
+
 
 @skipIfOffline()
 class IpfsApiLogTest(unittest.TestCase):


### PR DESCRIPTION
It's useful to get one block of a file, such as using libmagic to determine the file type.