### PR TITLE
Fix a Bug While Upload directories in Windows

### DIFF
--- a/ipfsapi/multipart.py
+++ b/ipfsapi/multipart.py
@@ -441,14 +441,14 @@ class DirectoryStream(BufferedGenerator):
                 mock_file.write(u'')
                 # Add this directory to those that will be sent
                 names.append(('files',
-                             (dir_base, mock_file, 'application/x-directory')))
+                             (dir_base.replace(os.sep, '/'), mock_file, 'application/x-directory')))
                 # Remember that this directory has already been sent
                 added_directories.add(dir_base)
 
         def add_file(short_path, full_path):
             try:
                 # Always add files in wildcard directories
-                names.append(('files', (short_name,
+                names.append(('files', (short_name.replace(os.sep, '/'),
                                         open(full_path, 'rb'),
                                         'application/octet-stream')))
             except OSError:


### PR DESCRIPTION
When add a directory in Windows System,the result always return with ```QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn```.
Because the dir separator using '\\' in Windows but needed is '/'.
I fix this bug for Python's ipfs api.