### PR TITLE
Fixed Issue 136 (Missing Word in Documentation)

### DIFF
--- a/docs/api_ref.md
+++ b/docs/api_ref.md
@@ -1,7 +1,7 @@
-Client API Reference
+﻿Client API Reference
 --------------------
 
-All commands are accessed through the `ipfsapi.Client` class.
+All commands are accessed through the ``ipfsapi.Client`` class.
 
 ### Exceptions
 
@@ -14,7 +14,7 @@ All commands are accessed through the `ipfsapi.Client` class.
 
 ### The API Client
 
-All methods accept the following parameters in their `kwargs`:
+All methods accept the following parameters in their ``kwargs``:
 
  * **opts** (*dict*) – A dictonary of custom parameters to be sent with the
                        HTTP request


### PR DESCRIPTION
The inline code was initially marked with a single back tick.  
The recommended way is with double back-ticks.  
I checked locally. Sphinx generated the proper HTML code, including the missing words.