### PR TITLE
Rewrite `ipfsapi/multipart.py` to address the issues mentioned in #104

### DIFF
--- a/ipfsapi/multipart.py
+++ b/ipfsapi/multipart.py
@@ -2,691 +2,713 @@
 """
 from __future__ import absolute_import
 
-import re
-import requests
-import io
+import inspect
 import os
-from inspect import isgenerator
-from uuid import uuid4
+import re
+from six.moves import urllib
+import uuid
 
 import six
 
-from six.moves.urllib.parse import quote
-
 from . import utils
 
-if six.PY3:
-    from builtins import memoryview as buffer
-
-
-CRLF = b'\r\n'
 
 default_chunk_size = 4096
 
 
-def content_disposition(fn, disptype='file'):
-    """Returns a dict containing the MIME content-disposition header for a file.
+#PY34: String formattings for binary types not supported
+if hasattr(six.binary_type, "__mod__"):
+	def bytes_fmt(b, *a):
+		return b % a
+else:
+	def bytes_fmt(base, *args):
+		# Decode each argument as ISO-8859-1 which causes each by to be
+		# reinterpreted as character
+		base = base.decode("iso-8859-1")
+		args = tuple(map(lambda b: bytes(b).decode("iso-8859-1"), args))
 
-    .. code-block:: python
-
-        >>> content_disposition('example.txt')
-        {'Content-Disposition': 'file; filename="example.txt"'}
-
-        >>> content_disposition('example.txt', 'attachment')
-        {'Content-Disposition': 'attachment; filename="example.txt"'}
-
-    Parameters
-    ----------
-    fn : str
-        Filename to retrieve the MIME content-disposition for
-    disptype : str
-        Rhe disposition type to use for the file
-    """
-    disp = '%s; filename="%s"' % (
-        disptype,
-        quote(fn, safe='')
-    )
-    return {'Content-Disposition': disp}
+		# Apply format and convert back
+		return (base % args).encode("iso-8859-1")
 
 
-def content_type(fn):
-    """Returns a dict with the content-type header for a file.
+def content_disposition_headers(filename, disptype="form-data"):
+	"""Returns a dict containing the MIME content-disposition header for a file.
 
-    Guesses the mimetype for a filename and returns a dict
-    containing the content-type header.
+	.. code-block:: python
 
-    .. code-block:: python
+		>>> content_disposition('example.txt')
+		{'Content-Disposition': 'form-data; filename="example.txt"'}
 
-        >>> content_type('example.txt')
-        {'Content-Type': 'text/plain'}
+		>>> content_disposition('example.txt', 'attachment')
+		{'Content-Disposition': 'attachment; filename="example.txt"'}
 
-        >>> content_type('example.jpeg')
-        {'Content-Type': 'image/jpeg'}
+	Parameters
+	----------
+	filename : str
+		Filename to retrieve the MIME content-disposition for
+	disptype : str
+		Rhe disposition type to use for the file
+	"""
+	disp = '%s; filename="%s"' % (
+		disptype,
+		urllib.parse.quote(filename, safe='')
+	)
+	return {'Content-Disposition': disp}
 
-        >>> content_type('example')
-        {'Content-Type': 'application/octet-stream'}
 
-    Parameters
-    ----------
-    fn : str
-        Filename to guess the content-type for
-    """
-    return {'Content-Type': utils.guess_mimetype(fn)}
+def content_type_headers(filename, content_type=None):
+	"""Returns a dict with the content-type header for a file.
+
+	Guesses the mimetype for a filename and returns a dict
+	containing the content-type header.
+
+	.. code-block:: python
+
+		>>> content_type('example.txt')
+		{'Content-Type': 'text/plain'}
+
+		>>> content_type('example.jpeg')
+		{'Content-Type': 'image/jpeg'}
+
+		>>> content_type('example')
+		{'Content-Type': 'application/octet-stream'}
+
+	Parameters
+	----------
+	filename : str
+		Filename to guess the content-type for
+	content_type : str
+		The Content-Type to use; if not set a content type will be guessed
+	"""
+	return {'Content-Type': content_type if content_type else utils.guess_mimetype(filename)}
 
 
 def multipart_content_type(boundary, subtype='mixed'):
-    """Creates a MIME multipart header with the given configuration.
+	"""Creates a MIME multipart header with the given configuration.
 
-    Returns a dict containing a MIME multipart header with the given
-    boundary.
+	Returns a dict containing a MIME multipart header with the given
+	boundary.
 
-    .. code-block:: python
+	.. code-block:: python
 
-        >>> multipart_content_type('8K5rNKlLQVyreRNncxOTeg')
-        {'Content-Type': 'multipart/mixed; boundary="8K5rNKlLQVyreRNncxOTeg"'}
+		>>> multipart_content_type('8K5rNKlLQVyreRNncxOTeg')
+		{'Content-Type': 'multipart/mixed; boundary="8K5rNKlLQVyreRNncxOTeg"'}
 
-        >>> multipart_content_type('8K5rNKlLQVyreRNncxOTeg', 'alt')
-        {'Content-Type': 'multipart/alt; boundary="8K5rNKlLQVyreRNncxOTeg"'}
+		>>> multipart_content_type('8K5rNKlLQVyreRNncxOTeg', 'alt')
+		{'Content-Type': 'multipart/alt; boundary="8K5rNKlLQVyreRNncxOTeg"'}
 
-    Parameters
-    ----------
-    boundry : str
-        The content delimiter to put into the header
-    subtype : str
-        The subtype in :mimetype:`multipart/*`-domain to put into the header
-    """
-    ctype = 'multipart/%s; boundary="%s"' % (
-        subtype,
-        boundary
-    )
-    return {'Content-Type': ctype}
-
-
-class BodyGenerator(object):
-    """Generators for creating the body of a :mimetype:`multipart/*`
-    HTTP request.
-
-    Parameters
-    ----------
-    name : str
-        The filename of the file(s)/content being encoded
-    disptype : str
-        The ``Content-Disposition`` of the content
-    subtype : str
-        The :mimetype:`multipart/*`-subtype of the content
-    boundary : str
-        An identifier used as a delimiter for the content's body
-    """
-
-    def __init__(self, name, disptype='file', subtype='mixed', boundary=None):
-        # If the boundary is unspecified, make a random one
-        if boundary is None:
-            boundary = self._make_boundary()
-        self.boundary = boundary
-
-        headers = content_disposition(name, disptype=disptype)
-        headers.update(multipart_content_type(boundary, subtype=subtype))
-        self.headers = headers
-
-    def _make_boundary(self):
-        """Returns a random hexadecimal string (UUID 4).
-
-        The HTTP multipart request body spec requires a boundary string to
-        separate different content chunks within a request, and this is
-        usually a random string. Using a UUID is an easy way to generate
-        a random string of appropriate length as this content separator.
-        """
-        return uuid4().hex
-
-    def _write_headers(self, headers):
-        """Yields the HTTP header text for some content.
-
-        Parameters
-        ----------
-        headers : dict
-            The headers to yield
-        """
-        if headers:
-            for name in sorted(headers.keys()):
-                yield name.encode("ascii")
-                yield b': '
-                yield headers[name].encode("ascii")
-                yield CRLF
-        yield CRLF
-
-    def write_headers(self):
-        """Yields the HTTP header text for the content."""
-        for c in self._write_headers(self.headers):
-            yield c
-
-    def open(self, **kwargs):
-        """Yields the body section for the content.
-        """
-        yield b'--'
-        yield self.boundary.encode()
-        yield CRLF
-
-    def file_open(self, fn):
-        """Yields the opening text of a file section in multipart HTTP.
-
-        Parameters
-        ----------
-        fn : str
-            Filename for the file being opened and added to the HTTP body
-        """
-        yield b'--'
-        yield self.boundary.encode()
-        yield CRLF
-        headers = content_disposition(fn)
-        headers.update(content_type(fn))
-        for c in self._write_headers(headers):
-            yield c
-
-    def file_close(self):
-        """Yields the end text of a file section in HTTP multipart encoding."""
-        yield CRLF
-
-    def close(self):
-        """Yields the ends of the content area in a HTTP multipart body."""
-        yield b'--'
-        yield self.boundary.encode()
-        yield b'--'
-        yield CRLF
+	Parameters
+	----------
+	boundary : str
+		The content delimiter to put into the header
+	subtype : str
+		The subtype in :mimetype:`multipart/*`-domain to put into the header
+	"""
+	ctype = 'multipart/%s; boundary="%s"' % (
+		subtype,
+		boundary
+	)
+	return {'Content-Type': ctype}
 
 
-class BufferedGenerator(object):
-    """Generator that encodes multipart/form-data.
 
-    An abstract buffered generator class which encodes
-    :mimetype:`multipart/form-data`.
+class StreamBase(object):
+	"""Generator that encodes multipart/form-data.
 
-    Parameters
-    ----------
-    name : str
-        The name of the file to encode
-    chunk_size : int
-        The maximum size that any single file chunk may have in bytes
-    """
+	An abstract buffered generator class which encodes
+	:mimetype:`multipart/form-data`.
 
-    def __init__(self, name, chunk_size=default_chunk_size):
-        self.chunk_size = chunk_size
-        self._internal = bytearray(chunk_size)
-        self.buf = buffer(self._internal)
+	Parameters
+	----------
+	name : str
+		The name of the file to encode
+	chunk_size : int
+		The maximum size that any single file chunk may have in bytes
+	"""
 
-        self.name = name
-        self.envelope = BodyGenerator(self.name,
-                                      disptype='form-data',
-                                      subtype='form-data')
-        self.headers = self.envelope.headers
+	def __init__(self, name, chunk_size=default_chunk_size):
+		self.chunk_size = chunk_size
+		self.name = name
 
-    def file_chunks(self, fp):
-        """Yields chunks of a file.
+		self._boundary = uuid.uuid4().hex
 
-        Parameters
-        ----------
-        fp : io.RawIOBase
-            The file to break into chunks
-            (must be an open file or have the ``readinto`` method)
-        """
-        fsize = utils.file_size(fp)
-        offset = 0
-        if hasattr(fp, 'readinto'):
-            while offset < fsize:
-                nb = fp.readinto(self._internal)
-                yield self.buf[:nb]
-                offset += nb
-        else:
-            while offset < fsize:
-                nb = min(self.chunk_size, fsize - offset)
-                yield fp.read(nb)
-                offset += nb
+		self._headers = content_disposition_headers(name, disptype='form-data')
+		self._headers.update(multipart_content_type(self._boundary, subtype='form-data'))
 
-    def gen_chunks(self, gen):
-        """Generates byte chunks of a given size.
+		#WORKAROUND: Go-IPFS randomly fucks up streaming requests if they are not
+		#            `Connection: close` (https://github.com/ipfs/go-ipfs/issues/5168)
+		self._headers["Connection"] = "close"
 
-        Takes a bytes generator and yields chunks of a maximum of
-        ``chunk_size`` bytes.
+		super(StreamBase, self).__init__()
 
-        Parameters
-        ----------
-        gen : generator
-            The bytes generator that produces the bytes
-        """
-        for data in gen:
-            size = len(data)
-            if size < self.chunk_size:
-                yield data
-            else:
-                mv = buffer(data)
-                offset = 0
-                while offset < size:
-                    nb = min(self.chunk_size, size - offset)
-                    yield mv[offset:offset + nb]
-                    offset += nb
+	def headers(self):
+		return self._headers.copy()
 
-    def body(self, *args, **kwargs):
-        """Returns the body of the buffered file.
+	def body(self, *args, **kwargs):
+		"""Returns the body of the buffered file.
 
-        .. note:: This function is not actually implemented.
-        """
-        raise NotImplementedError
+		.. note:: This function is not actually implemented.
+		"""
+		raise NotImplementedError
 
-    def close(self):
-        """Yields the closing text of a multipart envelope."""
-        for chunk in self.gen_chunks(self.envelope.close()):
-            yield chunk
+	def _gen_headers(self, headers):
+		"""Yields the HTTP header text for some content.
+
+		Parameters
+		----------
+		headers : dict
+			The headers to yield
+		"""
+		for name, value in headers.items():
+			yield bytes_fmt(b"%s: %s\r\n", name.encode("ascii"), value.encode("utf-8"))
+		yield b"\r\n"
+
+	def _gen_chunks(self, gen):
+		"""Generates byte chunks of a given size.
+
+		Takes a bytes generator and yields chunks of a maximum of
+		``chunk_size`` bytes.
+
+		Parameters
+		----------
+		gen : generator
+			The bytes generator that produces the bytes
+		"""
+		for data in gen:
+			#PERF: This is zero-copy if `len(data) <= self.chunk_size`
+			for offset in range(0, len(data), self.chunk_size):
+				yield data[offset:self.chunk_size]
+
+	def _gen_item_start(self):
+		"""Yields the body section for the content.
+		"""
+		yield bytes_fmt(b"--%s\r\n", self._boundary.encode("ascii"))
+
+	def _gen_item_end(self):
+		"""Yields the body section for the content.
+		"""
+		yield b"\r\n"
+
+	def _gen_end(self):
+		"""Yields the closing text of a multipart envelope."""
+		yield bytes_fmt(b'--%s--\r\n', self._boundary.encode("ascii"))
 
 
-class FileStream(BufferedGenerator):
-    """Generator that encodes multiples files into HTTP multipart.
+class StreamFileMixin(object):
+	def _gen_file(self, filename, file=None, content_type=None):
+		"""Yields the entire contents of a file.
 
-    A buffered generator that encodes an array of files as
-    :mimetype:`multipart/form-data`. This is a concrete implementation of
-    :class:`~ipfsapi.multipart.BufferedGenerator`.
+		Parameters
+		----------
+		filename : str
+			Filename of the file being opened and added to the HTTP body
+		file : io.RawIOBase
+			The binary file-like object whose contents should be streamed
 
-    Parameters
-    ----------
-    name : str
-        The filename of the file to encode
-    chunk_size : int
-        The maximum size that any single file chunk may have in bytes
-    """
+			No contents will be streamed if this is ``None``.
+		content_type : str
+			The Content-Type of the file; if not set a value will be guessed
+		"""
+		#PY2: Use `yield from` instead
+		for chunk in self._gen_file_start(filename, content_type): yield chunk
+		if file:
+			for chunk in self._gen_file_chunks(file): yield chunk
+		for chunk in self._gen_file_end(): yield chunk
 
-    def __init__(self, files, chunk_size=default_chunk_size):
-        BufferedGenerator.__init__(self, 'files', chunk_size=chunk_size)
+	def _gen_file_start(self, filename, content_type=None):
+		"""Yields the opening text of a file section in multipart HTTP.
 
-        self.files = utils.clean_files(files)
+		Parameters
+		----------
+		filename : str
+			Filename of the file being opened and added to the HTTP body
+		content_type : str
+			The Content-Type of the file; if not set a value will be guessed
+		"""
+		#PY2: Use `yield from` instead
+		for chunk in self._gen_item_start(): yield chunk
 
-    def body(self):
-        """Yields the body of the buffered file."""
-        for fp, need_close in self.files:
-            try:
-                name = os.path.basename(fp.name)
-            except AttributeError:
-                name = ''
-            for chunk in self.gen_chunks(self.envelope.file_open(name)):
-                yield chunk
-            for chunk in self.file_chunks(fp):
-                yield chunk
-            for chunk in self.gen_chunks(self.envelope.file_close()):
-                yield chunk
-            if need_close:
-                fp.close()
-        for chunk in self.close():
-            yield chunk
+		headers = content_disposition_headers(filename.replace(os.sep, "/"), disptype="file")
+		headers.update(content_type_headers(filename, content_type))
+		#PY2: Use `yield from` instead
+		for chunk in self._gen_headers(headers): yield chunk
+
+	def _gen_file_chunks(self, file):
+		"""Yields chunks of a file.
+
+		Parameters
+		----------
+		fp : io.RawIOBase
+			The file to break into chunks
+			(must be an open file or have the ``readinto`` method)
+		"""
+		while True:
+			buf = file.read(self.chunk_size)
+			if len(buf) < 1:
+				break
+			yield buf
+
+	def _gen_file_end(self):
+		"""Yields the end text of a file section in HTTP multipart encoding."""
+		return self._gen_item_end()
+
+
+class FilesStream(StreamBase, StreamFileMixin):
+	"""Generator that encodes multiples files into HTTP multipart.
+
+	A buffered generator that encodes an array of files as
+	:mimetype:`multipart/form-data`. This is a concrete implementation of
+	:class:`~ipfsapi.multipart.StreamBase`.
+
+	Parameters
+	----------
+	files : str | bytes | os.PathLike | io.IOBase | int | collections.abc.Iterable
+		The name, file object or file descriptor of the file to encode; may also
+		be a list of several items to allow for more efficient batch processing
+	chunk_size : int
+		The maximum size that any single file chunk may have in bytes
+	"""
+	def __init__(self, files, name="files", chunk_size=default_chunk_size):
+		self.files = utils.clean_files(files)
+
+		super(FilesStream, self).__init__(name, chunk_size=chunk_size)
+
+	def body(self):
+		"""Yields the body of the buffered file."""
+		for file, need_close in self.files:
+			try:
+				try:
+					filename = os.path.basename(file.name)
+				except AttributeError:
+					filename = ''
+
+				#PY2: Use `yield from` instead
+				for chunk in self._gen_file(filename, file): yield chunk
+			finally:
+				if need_close:
+					file.close()
+
+		#PY2: Use `yield from` instead
+		for chunk in self._gen_end(): yield chunk
 
 
 def glob_compile(pat):
-    """Translate a shell glob PATTERN to a regular expression.
+	"""Translate a shell glob PATTERN to a regular expression.
 
-    This is almost entirely based on `fnmatch.translate` source-code from the
-    python 3.5 standard-library.
-    """
+	This is almost entirely based on `fnmatch.translate` source-code from the
+	python 3.5 standard-library.
+	"""
 
-    i, n = 0, len(pat)
-    res = ''
-    while i < n:
-        c = pat[i]
-        i = i + 1
-        if c == '/' and len(pat) > (i + 2) and pat[i:(i + 3)] == '**/':
-            # Special-case for "any number of sub-directories" operator since
-            # may also expand to no entries:
-            #  Otherwise `a/**/b` would expand to `a[/].*[/]b` which wouldn't
-            #  match the immediate sub-directories of `a`, like `a/b`.
-            i = i + 3
-            res = res + '[/]([^/]*[/])*'
-        elif c == '*':
-            if len(pat) > i and pat[i] == '*':
-                i = i + 1
-                res = res + '.*'
-            else:
-                res = res + '[^/]*'
-        elif c == '?':
-            res = res + '[^/]'
-        elif c == '[':
-            j = i
-            if j < n and pat[j] == '!':
-                j = j + 1
-            if j < n and pat[j] == ']':
-                j = j + 1
-            while j < n and pat[j] != ']':
-                j = j + 1
-            if j >= n:
-                res = res + '\\['
-            else:
-                stuff = pat[i:j].replace('\\', '\\\\')
-                i = j + 1
-                if stuff[0] == '!':
-                    stuff = '^' + stuff[1:]
-                elif stuff[0] == '^':
-                    stuff = '\\' + stuff
-                res = '%s[%s]' % (res, stuff)
-        else:
-            res = res + re.escape(c)
-    return re.compile('^' + res + '\Z(?ms)' + '$')
-
-
-class DirectoryStream(BufferedGenerator):
-    """Generator that encodes a directory into HTTP multipart.
-
-    A buffered generator that encodes an array of files as
-    :mimetype:`multipart/form-data`. This is a concrete implementation of
-    :class:`~ipfsapi.multipart.BufferedGenerator`.
-
-    Parameters
-    ----------
-    directory : str
-        The filepath of the directory to encode
-    patterns : str | list
-        A single glob pattern or a list of several glob patterns and
-        compiled regular expressions used to determine which filepaths to match
-    chunk_size : int
-        The maximum size that any single file chunk may have in bytes
-    """
-
-    def __init__(self,
-                 directory,
-                 recursive=False,
-                 patterns='**',
-                 chunk_size=default_chunk_size):
-        BufferedGenerator.__init__(self, directory, chunk_size=chunk_size)
-
-        self.patterns = []
-        patterns = [patterns] if isinstance(patterns, str) else patterns
-        for pattern in patterns:
-            if isinstance(pattern, str):
-                self.patterns.append(glob_compile(pattern))
-            else:
-                self.patterns.append(pattern)
-
-        self.directory = os.path.normpath(directory)
-        self.recursive = recursive
-        self._request = self._prepare()
-        self.headers = self._request.headers
-
-    def body(self):
-        """Returns the HTTP headers for this directory upload request."""
-        return self._request.body
-
-    def headers(self):
-        """Returns the HTTP body for this directory upload request."""
-        return self._request.headers
-
-    def _prepare(self):
-        """Pre-formats the multipart HTTP request to transmit the directory."""
-        names = []
-
-        added_directories = set()
-
-        def add_directory(short_path):
-            # Do not continue if this directory has already been added
-            if short_path in added_directories:
-                return
-
-            # Scan for first super-directory that has already been added
-            dir_base  = short_path
-            dir_parts = []
-            while dir_base:
-                dir_base, dir_name = os.path.split(dir_base)
-                dir_parts.append(dir_name)
-                if dir_base in added_directories:
-                    break
-
-            # Add missing intermediate directory nodes in the right order
-            while dir_parts:
-                dir_base = os.path.join(dir_base, dir_parts.pop())
-
-                # Create an empty, fake file to represent the directory
-                mock_file = io.StringIO()
-                mock_file.write(u'')
-                # Add this directory to those that will be sent
-                names.append(('files',
-                             (dir_base.replace(os.sep, '/'), mock_file, 'application/x-directory')))
-                # Remember that this directory has already been sent
-                added_directories.add(dir_base)
-
-        def add_file(short_path, full_path):
-            try:
-                # Always add files in wildcard directories
-                names.append(('files', (short_name.replace(os.sep, '/'),
-                                        open(full_path, 'rb'),
-                                        'application/octet-stream')))
-            except OSError:
-                # File might have disappeared between `os.walk()` and `open()`
-                pass
-
-        def match_short_path(short_path):
-            # Remove initial path component so that all files are based in
-            # the target directory itself (not one level above)
-            if os.sep in short_path:
-                path = short_path.split(os.sep, 1)[1]
-            else:
-                return False
-
-            # Convert all path seperators to POSIX style
-            path = path.replace(os.sep, '/')
-
-            # Do the matching and the simplified path
-            for pattern in self.patterns:
-                if pattern.match(path):
-                    return True
-            return False
-
-        # Identify the unecessary portion of the relative path
-        truncate = os.path.dirname(self.directory)
-        # Traverse the filesystem downward from the target directory's uri
-        # Errors: `os.walk()` will simply return an empty generator if the
-        #         target directory does not exist.
-        wildcard_directories = set()
-        for curr_dir, _, files in os.walk(self.directory):
-            # find the path relative to the directory being added
-            if len(truncate) > 0:
-                _, _, short_path = curr_dir.partition(truncate)
-            else:
-                short_path = curr_dir
-            # remove leading / or \ if it is present
-            if short_path.startswith(os.sep):
-                short_path = short_path[1:]
-
-            wildcard_directory = False
-            if os.path.split(short_path)[0] in wildcard_directories:
-                # Parent directory has matched a pattern, all sub-nodes should
-                # be added too
-                wildcard_directories.add(short_path)
-                wildcard_directory = True
-            else:
-                # Check if directory path matches one of the patterns
-                if match_short_path(short_path):
-                    # Directory matched pattern and it should therefor
-                    # be added along with all of its contents
-                    wildcard_directories.add(short_path)
-                    wildcard_directory = True
-
-            # Always add directories within wildcard directories - even if they
-            # are empty
-            if wildcard_directory:
-                add_directory(short_path)
-
-            # Iterate across the files in the current directory
-            for filename in files:
-                # Find the filename relative to the directory being added
-                short_name = os.path.join(short_path, filename)
-                filepath = os.path.join(curr_dir, filename)
-
-                if wildcard_directory:
-                    # Always add files in wildcard directories
-                    add_file(short_name, filepath)
-                else:
-                    # Add file (and all missing intermediary directories)
-                    # if it matches one of the patterns
-                    if match_short_path(short_name):
-                        add_directory(short_path)
-                        add_file(short_name, filepath)
-        # Send the request and present the response body to the user
-        req = requests.Request("POST", 'http://localhost', files=names)
-        prep = req.prepare()
-        return prep
+	i, n = 0, len(pat)
+	res = ''
+	while i < n:
+		c = pat[i]
+		i = i + 1
+		if c == '/' and len(pat) > (i + 2) and pat[i:(i + 3)] == '**/':
+			# Special-case for "any number of sub-directories" operator since
+			# may also expand to no entries:
+			#  Otherwise `a/**/b` would expand to `a[/].*[/]b` which wouldn't
+			#  match the immediate sub-directories of `a`, like `a/b`.
+			i = i + 3
+			res = res + '[/]([^/]*[/])*'
+		elif c == '*':
+			if len(pat) > i and pat[i] == '*':
+				i = i + 1
+				res = res + '.*'
+			else:
+				res = res + '[^/]*'
+		elif c == '?':
+			res = res + '[^/]'
+		elif c == '[':
+			j = i
+			if j < n and pat[j] == '!':
+				j = j + 1
+			if j < n and pat[j] == ']':
+				j = j + 1
+			while j < n and pat[j] != ']':
+				j = j + 1
+			if j >= n:
+				res = res + '\\['
+			else:
+				stuff = pat[i:j].replace('\\', '\\\\')
+				i = j + 1
+				if stuff[0] == '!':
+					stuff = '^' + stuff[1:]
+				elif stuff[0] == '^':
+					stuff = '\\' + stuff
+				res = '%s[%s]' % (res, stuff)
+		else:
+			res = res + re.escape(c)
+	return re.compile('^' + res + '\\Z(?ms)' + '$')
 
 
-class BytesStream(BufferedGenerator):
-    """A buffered generator that encodes bytes as
-    :mimetype:`multipart/form-data`.
+class DirectoryStream(StreamBase, StreamFileMixin):
+	"""Generator that encodes a directory into HTTP multipart.
 
-    Parameters
-    ----------
-    data : bytes
-        The binary data to stream to the daemon
-    chunk_size : int
-        The maximum size of a single data chunk
-    """
+	A buffered generator that encodes an array of files as
+	:mimetype:`multipart/form-data`. This is a concrete implementation of
+	:class:`~ipfsapi.multipart.StreamBase`.
 
-    def __init__(self, data, chunk_size=default_chunk_size):
-        BufferedGenerator.__init__(self, 'bytes', chunk_size=chunk_size)
+	Parameters
+	----------
+	directory : str | os.PathLike | int
+		The filepath or file descriptor of the directory to encode
 
-        self.data = data if isgenerator(data) else (data,)
+		File descriptors are only supported on Unix and Python 3.
+	dirname : str | None
+		The name of the base directroy to upload, use ``None`` for
+		the default of ``os.path.basename(directory) || '.'``
+	patterns : str | re.compile | collections.abc.Iterable
+		A single glob pattern or a list of several glob patterns and
+		compiled regular expressions used to determine which filepaths to match
+	chunk_size : int
+		The maximum size that any single file chunk may have in bytes
+	"""
+	def __init__(self, directory,
+	             recursive=False, patterns='**', dirname=None,
+	             chunk_size=default_chunk_size):
+		self.patterns = []
+		patterns = [patterns] if isinstance(patterns, str) else patterns
+		for pattern in patterns:
+			self.patterns.append(glob_compile(pattern) if isinstance(pattern, str) else pattern)
 
-    def body(self):
-        """Yields the encoded body."""
-        for chunk in self.gen_chunks(self.envelope.file_open(self.name)):
-            yield chunk
-        for chunk in self.gen_chunks(self.data):
-            yield chunk
-        for chunk in self.gen_chunks(self.envelope.file_close()):
-            yield chunk
-        for chunk in self.close():
-            yield chunk
+		self.directory = directory
+		if not isinstance(self.directory, int):
+			self.directory = os.path.normpath(directory)
+		self.recursive = recursive
+		self.dirname   = dirname
+
+		name = os.path.basename(directory) if not isinstance(directory, int) else ""
+		super(DirectoryStream, self).__init__(name, chunk_size=chunk_size)
+
+	def _body_directory(self, short_path, visited_directories):
+		# Do not continue if this directory has already been added
+		if short_path in visited_directories:
+			return
+
+		# Scan for first super-directory that has already been added
+		dir_base  = short_path
+		dir_parts = []
+		while dir_base:
+			dir_base, dir_name = os.path.split(dir_base)
+			dir_parts.append(dir_name)
+			if dir_base in visited_directories:
+				break
+
+		# Add missing intermediate directory nodes in the right order
+		while dir_parts:
+			dir_base = os.path.join(dir_base, dir_parts.pop())
+
+			# Generate directory as special empty file
+			#PY2: Use `yield from` instead
+			for chunk in self._gen_file(dir_base, content_type="application/x-directory"):
+				yield chunk
+
+			# Remember that this directory has already been sent
+			visited_directories.add(dir_base)
+
+	def _body_file(self, short_path, file_location, dir_fd=-1):
+		try:
+			if dir_fd >= 0:
+				file_location = os.open(file_location, os.O_RDONLY | os.O_CLOEXEC, dir_fd=dir_fd)
+			# Stream file to client
+			with open(file_location, "rb") as file:
+				#PY2: Use `yield from`
+				for chunk in self._gen_file(short_path, file): yield chunk
+		except OSError as e:
+			print(e)
+			# File might have disappeared between `os.walk()` and `open()`
+			pass
+
+	def body(self):
+		"""Streams the contents of the selected directory as binary chunks."""
+		def match_short_path(short_path):
+			# Remove initial path component so that all files are based in
+			# the target directory itself (not one level above)
+			if os.path.sep in short_path:
+				path = short_path.split(os.path.sep, 1)[1]
+			else:
+				return False
+
+			# Convert all path seperators to POSIX style
+			path = path.replace(os.path.sep, '/')
+
+			# Do the matching and the simplified path
+			for pattern in self.patterns:
+				if pattern.match(path):
+					return True
+			return False
+
+		visited_directories = set()
+
+		# Normalize directory path without destroying symlinks
+		sep = os.path.sep
+		directory = self.directory
+		if not isinstance(self.directory, int):
+			directory = os.fspath(directory) if hasattr(os, "fspath") else directory
+			if not isinstance(directory, str):
+				sep = os.fsencode(sep)
+			while sep * 2 in directory:
+				directory.replace(sep * 2, sep)
+			if directory.endswith(sep):
+				directory = directory[:-len(sep)]
+
+		# Determine base directory name to send to IPFS (required and also used
+		# as part of the wrap_with_directory feature)
+		if self.dirname:
+			dirname = self.dirname
+		elif not isinstance(directory, int):
+			dirname = os.path.basename(directory)
+			dirname = dirname if isinstance(dirname, str) else os.fsdecode(dirname)
+		else:
+			dirname = "_" if isinstance(directory, (str, int)) else os.fsencode("_")
+		assert(type(directory) == type(dirname) or isinstance(directory, int))
+
+		# Identify the unnecessary portion of the relative path
+		truncate = (directory if not isinstance(directory, int) else ".") + sep
+		# Traverse the filesystem downward from the target directory's uri
+		# Errors: `os.walk()` will simply return an empty generator if the
+		#         target directory does not exist.
+		wildcard_directories = set()
+
+		if not isinstance(self.directory, int):
+			walk_iter = os.walk(self.directory)
+		else:
+			walk_iter = os.fwalk(dir_fd=self.directory)
+		for result in walk_iter:
+			cur_dir, filenames = result[0], result[2]
+			dir_fd = -1 if not isinstance(self.directory, int) else result[3]
+
+			# find the path relative to the directory being added
+			if len(truncate) > 0:
+				_, _, short_path = cur_dir.partition(truncate)
+			else:
+				short_path = cur_dir
+				# remove leading / or \ if it is present
+				if short_path.startswith(os.path.sep):
+					short_path = short_path[len(os.path.sep):]
+			short_path = os.path.join(dirname, short_path)
+
+			wildcard_directory = False
+			if os.path.split(short_path)[0] in wildcard_directories:
+				# Parent directory has matched a pattern, all sub-nodes should
+				# be added too
+				wildcard_directories.add(short_path)
+				wildcard_directory = True
+			else:
+				# Check if directory path matches one of the patterns
+				if match_short_path(short_path):
+					# Directory matched pattern and it should therefor
+					# be added along with all of its contents
+					wildcard_directories.add(short_path)
+					wildcard_directory = True
+
+			# Always add directories within wildcard directories - even if they
+			# are empty
+			if wildcard_directory:
+				#PY2: Use `yield from` instead
+				for chunk in self._body_directory(short_path, visited_directories): yield chunk
+
+			# Iterate across the files in the current directory
+			for filename in filenames:
+				# Find the filename relative to the directory being added
+				short_file_path = os.path.join(short_path, filename)
+				if dir_fd < 0:
+					file_location = os.path.join(cur_dir, filename)
+				else:
+					file_location = filename
+
+				if wildcard_directory:
+					# Always add files in wildcard directories
+					#PY2: Use `yield from` instead
+					for chunk in self._body_file(short_file_path, file_location, dir_fd=dir_fd):
+						yield chunk
+				else:
+					# Add file (and all missing intermediary directories)
+					# if it matches one of the patterns
+					if match_short_path(short_file_path):
+						#PY2: Use `yield from` instead
+						for chunk in self._body_directory(short_path, visited_directories):
+							yield chunk
+						for chunk in self._body_file(short_file_path, file_location, dir_fd=dir_fd):
+							yield chunk
+
+		#PY2: Use `yield from` instead
+		for chunk in self._gen_end(): yield chunk
+
+
+class BytesFileStream(FilesStream):
+	"""A buffered generator that encodes bytes as file in
+	:mimetype:`multipart/form-data`.
+
+	Parameters
+	----------
+	data : bytes
+		The binary data to stream to the daemon
+	chunk_size : int
+		The maximum size of a single data chunk
+	"""
+	def __init__(self, data, name="bytes", chunk_size=default_chunk_size):
+		super(BytesFileStream, self).__init__([], name=name, chunk_size=chunk_size)
+
+		self.data = data if inspect.isgenerator(data) else (data,)
+
+	def body(self):
+		"""Yields the encoded body."""
+		#PY2: Use `yield from` instead
+		for chunk in self._gen_file_start(self.name): yield chunk
+		for chunk in self._gen_chunks(self.data): yield chunk
+		for chunk in self._gen_file_end(): yield chunk
+		for chunk in self._gen_end(): yield chunk
 
 
 def stream_files(files, chunk_size=default_chunk_size):
-    """Gets a buffered generator for streaming files.
+	"""Gets a buffered generator for streaming files.
 
-    Returns a buffered generator which encodes a file or list of files as
-    :mimetype:`multipart/form-data` with the corresponding headers.
+	Returns a buffered generator which encodes a file or list of files as
+	:mimetype:`multipart/form-data` with the corresponding headers.
 
-    Parameters
-    ----------
-    files : str
-        The file(s) to stream
-    chunk_size : int
-        Maximum size of each stream chunk
-    """
-    stream = FileStream(files, chunk_size=chunk_size)
-
-    return stream.body(), stream.headers
-
-
-def stream_directory(directory,
-                     recursive=False,
-                     patterns='**',
-                     chunk_size=default_chunk_size):
-    """Gets a buffered generator for streaming directories.
-
-    Returns a buffered generator which encodes a directory as
-    :mimetype:`multipart/form-data` with the corresponding headers.
-
-    Parameters
-    ----------
-    directory : str
-        The filepath of the directory to stream
-    recursive : bool
-        Stream all content within the directory recursively?
-    patterns : str | list
-        Single *glob* pattern or list of *glob* patterns and compiled
-        regular expressions to match the names of the filepaths to keep
-    chunk_size : int
-        Maximum size of each stream chunk
-    """
-    stream = DirectoryStream(directory,
-                             recursive=recursive,
-                             patterns=patterns,
-                             chunk_size=chunk_size)
-
-    return stream.body(), stream.headers
+	Parameters
+	----------
+	files : str | bytes | os.PathLike | io.IOBase | int | collections.abc.Iterable
+		The file(s) to stream
+	chunk_size : int
+		Maximum size of each stream chunk
+	"""
+	stream = FilesStream(files, chunk_size=chunk_size)
+	return stream.body(), stream.headers()
 
 
-def stream_filesystem_node(path,
-                           recursive=False,
-                           patterns='**',
+def stream_directory(directory, recursive=False, patterns='**', chunk_size=default_chunk_size):
+	"""Gets a buffered generator for streaming directories.
+
+	Returns a buffered generator which encodes a directory as
+	:mimetype:`multipart/form-data` with the corresponding headers.
+
+	Parameters
+	----------
+	directory : str | bytes | os.PathLike | int
+		The filepath of the directory to stream
+	recursive : bool
+		Stream all content within the directory recursively?
+	patterns : str | re.compile | collections.abc.Iterable
+		Single *glob* pattern or list of *glob* patterns and compiled
+		regular expressions to match the names of the filepaths to keep
+	chunk_size : int
+		Maximum size of each stream chunk
+	"""
+	def stream_directory_impl(directory, dirname=None):
+		stream = DirectoryStream(directory,
+		                         recursive=recursive, patterns=patterns,
+		                         dirname=dirname, chunk_size=chunk_size)
+		return stream.body(), stream.headers()
+
+	# Note that `os.fwalk` is never available on Windows and Python 2
+	if hasattr(os, "fwalk") and not isinstance(directory, int):
+		def auto_close_iter_fd(fd, iter):
+			try:
+				#PY2: Use `yield from` instead
+				for item in iter:
+					yield item
+			finally:
+				os.close(fd)
+
+		dirname = os.path.basename(os.path.normpath(directory))
+
+		fd = os.open(directory, os.O_CLOEXEC | os.O_DIRECTORY)
+		body, headers = stream_directory_impl(fd, dirname)
+		return auto_close_iter_fd(fd, body), headers
+	else:
+		return stream_directory_impl(directory)
+
+
+def stream_filesystem_node(filepaths,
+                           recursive=False, patterns='**',
                            chunk_size=default_chunk_size):
-    """Gets a buffered generator for streaming either files or directories.
+	"""Gets a buffered generator for streaming either files or directories.
 
-    Returns a buffered generator which encodes the file or directory at the
-    given path as :mimetype:`multipart/form-data` with the corresponding
-    headers.
+	Returns a buffered generator which encodes the file or directory at the
+	given path as :mimetype:`multipart/form-data` with the corresponding
+	headers.
 
-    Parameters
-    ----------
-    path : str
-        The filepath of the directory or file to stream
-    recursive : bool
-        Stream all content within the directory recursively?
-    patterns : str | list
-        Single *glob* pattern or list of *glob* patterns and compiled
-        regular expressions to match the names of the filepaths to keep
-    chunk_size : int
-        Maximum size of each stream chunk
-    """
-    is_dir = isinstance(path, six.string_types) and os.path.isdir(path)
-    if recursive or is_dir:
-        return stream_directory(path, recursive, patterns, chunk_size)
-    else:
-        return stream_files(path, chunk_size)
+	Parameters
+	----------
+	filepaths : str | bytes | os.PathLike | int | io.IOBase | collections.abc.Iterable
+		The filepath of a single directory or one or more files to stream
+	recursive : bool
+		Stream all content within the directory recursively?
+	patterns : str | re.compile | collections.abc.Iterable
+		Single *glob* pattern or list of *glob* patterns and compiled
+		regular expressions to match the paths of files and directories
+		to be added to IPFS (directories only)
+	chunk_size : int
+		Maximum size of each stream chunk
+	"""
+	is_dir = False
+	if isinstance(filepaths, utils.path_types):
+		is_dir = os.path.isdir(filepaths)
+	elif isinstance(filepaths, int):
+		import stat
+		is_dir = stat.S_ISDIR(os.fstat(filepaths).st_mode)
+	if recursive or is_dir:
+		return stream_directory(filepaths, recursive, patterns, chunk_size)
+	else:
+		return stream_files(filepaths, chunk_size)
 
 
 def stream_bytes(data, chunk_size=default_chunk_size):
-    """Gets a buffered generator for streaming binary data.
+	"""Gets a buffered generator for streaming binary data.
 
-    Returns a buffered generator which encodes binary data as
-    :mimetype:`multipart/form-data` with the corresponding headers.
+	Returns a buffered generator which encodes binary data as
+	:mimetype:`multipart/form-data` with the corresponding headers.
 
-    Parameters
-    ----------
-    data : bytes
-        The data bytes to stream
-    chunk_size : int
-        The maximum size of each stream chunk
+	Parameters
+	----------
+	data : bytes
+		The data bytes to stream
+	chunk_size : int
+		The maximum size of each stream chunk
 
-    Returns
-    -------
-        (generator, dict)
-    """
-    stream = BytesStream(data, chunk_size=chunk_size)
-
-    return stream.body(), stream.headers
+	Returns
+	-------
+		(generator, dict)
+	"""
+	stream = BytesFileStream(data, chunk_size=chunk_size)
+	return stream.body(), stream.headers()
 
 
 def stream_text(text, chunk_size=default_chunk_size):
-    """Gets a buffered generator for streaming text.
+	"""Gets a buffered generator for streaming text.
 
-    Returns a buffered generator which encodes a string as
-    :mimetype:`multipart/form-data` with the corresponding headers.
+	Returns a buffered generator which encodes a string as
+	:mimetype:`multipart/form-data` with the corresponding headers.
 
-    Parameters
-    ----------
-    text : str
-        The data bytes to stream
-    chunk_size : int
-        The maximum size of each stream chunk
+	Parameters
+	----------
+	text : str
+		The data bytes to stream
+	chunk_size : int
+		The maximum size of each stream chunk
 
-    Returns
-    -------
-        (generator, dict)
-    """
-    if isgenerator(text):
-        def binary_stream():
-            for item in text:
-                if six.PY2 and isinstance(text, six.binary_type):
-                    #PY2: Allow binary strings under Python 2 since
-                    # Python 2 code is not expected to always get the
-                    # distinction between text and binary strings right.
-                    yield text
-                else:
-                    yield text.encode("utf-8")
-        data = binary_stream()
-    elif six.PY2 and isinstance(text, six.binary_type):
-        #PY2: See above.
-        data = text
-    else:
-        data = text.encode("utf-8")
+	Returns
+	-------
+		(generator, dict)
+	"""
+	if inspect.isgenerator(text):
+		def binary_stream():
+			for item in text:
+				if six.PY2 and isinstance(item, six.binary_type):
+					#PY2: Allow binary strings under Python 2 since
+					# Python 2 code is not expected to always get the
+					# distinction between text and binary strings right.
+					yield item
+				else:
+					yield item.encode("utf-8")
+		data = binary_stream()
+	elif six.PY2 and isinstance(text, six.binary_type):
+		#PY2: See above.
+		data = text
+	else:
+		data = text.encode("utf-8")
 
-    return stream_bytes(data, chunk_size)
+	return stream_bytes(data, chunk_size)

--- a/requirements-codestyle.txt
+++ b/requirements-codestyle.txt
@@ -1,1 +1,2 @@
 flake8
+flake8-expandtab~=0.3

--- a/requirements-codestyle.txt
+++ b/requirements-codestyle.txt
@@ -1,2 +1,3 @@
-flake8
+flake8~=3.0
+flake8-per-file-ignores~=0.6
 flake8-expandtab~=0.3

--- a/test/unit/test_multipart.py
+++ b/test/unit/test_multipart.py
@@ -3,16 +3,17 @@
 Classes:
 TestContentHelpers -- test the three content-header helper functions
 TestBodyGenerator -- test the BodyGenerator helper class
-TestBufferedGenerator -- test the BufferedGenerator helper class
+TestStreamBase -- test the StreamBase helper class
 TestFileStream -- test the FileStream generator class
 TestDirectoryStream -- test the DirectoryStream generator class
 TestTextStream -- test the TextStream generator class
 TestStreamHelpers -- unimplemented
 """
 
-import unittest
+import io
 import os
 import re
+import unittest
 
 import pytest
 import six
@@ -21,382 +22,339 @@ import ipfsapi.multipart
 
 
 class TestContentHelpers(unittest.TestCase):
-    """Tests the functionality of the three content-oriented helper functions.
+	"""Tests the functionality of the three content-oriented helper functions.
 
-    Public methods:
-    test_content_disposition -- check the content_disposition defaults
-    test_content_disposition_with_type -- check that content_disposition
-                                            handles given disposition type
-    test_content_type -- check the content_type guessing functionality
-    test_multipart_content_type -- check multipart_content_type functionality
-    """
+	Public methods:
+	test_content_disposition_headers -- check the content_disposition defaults
+	test_content_disposition_headers_with_type -- check that content_disposition
+												  handles given disposition type
+	test_content_headers_type -- check the content_type guessing functionality
+	test_multipart_content_type_headers -- check multipart_content_type_headers functionality
+	"""
 
-    def test_content_disposition(self):
-        """Check that content_disposition defaults properly"""
-        expected = {'Content-Disposition': 'file; filename="example.txt"'}
-        actual = ipfsapi.multipart.content_disposition('example.txt')
-        assert expected == actual
+	def test_content_disposition_headers(self):
+		"""Check that content_disposition defaults properly"""
+		expected = {'Content-Disposition': 'form-data; filename="example.txt"'}
+		actual = ipfsapi.multipart.content_disposition_headers('example.txt')
+		assert expected == actual
 
-    def test_content_disposition_with_type(self):
-        """Check that content_disposition handles given disposition type"""
-        expected = {'Content-Disposition':
-                    'attachment; filename="example.txt"'}
-        actual = ipfsapi.multipart.content_disposition('example.txt',
-                                                       'attachment')
-        assert expected == actual
+	def test_content_disposition_headers_with_type(self):
+		"""Check that content_disposition handles given disposition type"""
+		expected = {'Content-Disposition': 'attachment; filename="example.txt"'}
+		actual = ipfsapi.multipart.content_disposition_headers('example.txt', 'attachment')
+		assert expected == actual
 
-    def test_content_type(self):
-        """Check the content_type guessing functionality."""
-        actual = ipfsapi.multipart.content_type('example.txt')
-        expected = {'Content-Type': 'text/plain'}
-        assert expected == actual
+	def test_content_type_headers(self):
+		"""Check the content_type guessing functionality."""
+		actual = ipfsapi.multipart.content_type_headers('example.txt')
+		expected = {'Content-Type': 'text/plain'}
+		assert expected == actual
 
-        actual = ipfsapi.multipart.content_type('example.jpeg')
-        expected = {'Content-Type': 'image/jpeg'}
-        assert expected == actual
+		actual = ipfsapi.multipart.content_type_headers('example.jpeg')
+		expected = {'Content-Type': 'image/jpeg'}
+		assert expected == actual
 
-        actual = ipfsapi.multipart.content_type('example')
-        expected = {'Content-Type': 'application/octet-stream'}
-        assert expected == actual
+		actual = ipfsapi.multipart.content_type_headers('example')
+		expected = {'Content-Type': 'application/octet-stream'}
+		assert expected == actual
 
-    def test_multipart_content_type(self):
-        """Check test_multipart_content_type functionality."""
-        actual = ipfsapi.multipart.multipart_content_type(
-            '8K5rNKlLQVyreRNncxOTeg')
-        expected = {'Content-Type':
-                    'multipart/mixed; boundary="8K5rNKlLQVyreRNncxOTeg"'}
-        assert expected == actual
+	def test_multipart_content_type_headers(self):
+		"""Check test_multipart_content_type_headers functionality."""
+		actual = ipfsapi.multipart.multipart_content_type_headers('8K5rNKlLQVyreRNncxOTeg')
+		expected = {'Content-Type': 'multipart/mixed; boundary="8K5rNKlLQVyreRNncxOTeg"'}
+		assert expected == actual
 
-        actual = ipfsapi.multipart.multipart_content_type(
-            '8K5rNKlLQVyreRNncxOTeg', 'alt')
-        expected = {'Content-Type':
-                    'multipart/alt; boundary="8K5rNKlLQVyreRNncxOTeg"'}
-        assert expected == actual
+		actual = ipfsapi.multipart.multipart_content_type_headers('8K5rNKlLQVyreRNncxOTeg', 'alt')
+		expected = {'Content-Type': 'multipart/alt; boundary="8K5rNKlLQVyreRNncxOTeg"'}
+		assert expected == actual
 
 
 class TestBodyGenerator(unittest.TestCase):
-    """Tests the functionality of the BodyGenerator class.
+	"""Tests the functionality of the BodyGenerator class.
 
-    Public methods:
-    test_init_defaults -- tests the constructor and its behavior with only the
-                            required argument
-    test_init_with_all -- tests the constructor when all arguments are set
-                            explicitly
-    test_write_headers -- tests write_headers function against example output
-    test_open -- tests open function against example output
-    test_file_open -- test file_open function against example output
-    test_file_close -- test file_close function against example output
-    test_close -- test close function against example output
-    """
+	Public methods:
+	"""
 
-    def test_init_defaults(self):
-        """Test the __init__ function for default parameter values."""
-        name = "test_name"
-        expected_disposition = 'file; filename="test_name"'
-        expected_type = 'multipart/mixed; boundary="\S*"'
-        expected_boundary_pattern = '\S*'
-        generator = ipfsapi.multipart.BodyGenerator(name)
-        assert generator.headers['Content-Disposition'] == expected_disposition
-        assert re.search(expected_type,             generator.headers['Content-Type'])
-        assert re.search(expected_boundary_pattern, generator.boundary)
 
-    def test_init_with_all(self):
-        """Test the __init__ function for explicitly set parameter values."""
-        name = "test_name"
-        disptype = "test_disp"
-        subtype = "test_subtype"
-        boundary = "test_boundary"
-        generator = ipfsapi.multipart.BodyGenerator(name, disptype,
-                                                    subtype, boundary)
-        assert generator.headers == {
-            'Content-Disposition': 'test_disp; filename="test_name"',
-            'Content-Type':
-            'multipart/test_subtype; boundary="test_boundary"'}
-        assert generator.boundary == boundary
-
-    def test_write_headers(self):
-        """Test the write_headers function against sample output."""
-        expected = 'Content-Disposition: test_disp; filename="test_name"' \
-                   + '\r\nContent-Type: multipart/test_subtype; ' \
-                   + 'boundary="test_boundary"\r\n\r\n'
-        name = "test_name"
-        disptype = "test_disp"
-        subtype = "test_subtype"
-        boundary = "test_boundary"
-        generator = ipfsapi.multipart.BodyGenerator(name, disptype,
-                                                    subtype, boundary)
-        headers = ""
-        for chunk in generator.write_headers():
-            if type(chunk) is not str:
-                chunk = chunk.decode()
-            headers += chunk
-        assert headers == expected
-
-    def test_open(self):
-        """Test the open function against sample output."""
-        expected = '--test_boundary\r\n'
-        name = "test_name"
-        disptype = "test_disp"
-        subtype = "test_subtype"
-        boundary = "test_boundary"
-        generator = ipfsapi.multipart.BodyGenerator(name, disptype,
-                                                    subtype, boundary)
-        headers = ""
-        for chunk in generator.open():
-            if type(chunk) is not str:
-                chunk = chunk.decode()
-            headers += chunk
-        assert headers == expected
-
-    def test_file_open(self):
-        """Test the file_open function against sample output."""
-        expected = '--test_boundary\r\nContent-Disposition: file; '\
-            + 'filename="test_name"\r\nContent-Type: '\
-            + 'application/octet-stream\r\n\r\n'
-        name = "test_name"
-        disptype = "test_disp"
-        subtype = "test_subtype"
-        boundary = "test_boundary"
-        generator = ipfsapi.multipart.BodyGenerator(name, disptype,
-                                                    subtype, boundary)
-        headers = ""
-        for chunk in generator.file_open(name):
-            if type(chunk) is not str:
-                chunk = chunk.decode()
-            headers += chunk
-        assert headers == expected
-
-    def test_file_close(self):
-        """Test the file_close function against sample output."""
-        expected = '\r\n'
-        name = "test_name"
-        disptype = "test_disp"
-        subtype = "test_subtype"
-        boundary = "test_boundary"
-        generator = ipfsapi.multipart.BodyGenerator(name, disptype,
-                                                    subtype, boundary)
-        headers = ""
-        for chunk in generator.file_close():
-            if type(chunk) is not str:
-                chunk = chunk.decode()
-            headers += chunk
-        assert headers == expected
-
-    def test_close(self):
-        """Test the close function against sample output."""
-        expected = '--test_boundary--\r\n'
-        name = "test_name"
-        disptype = "test_disp"
-        subtype = "test_subtype"
-        boundary = "test_boundary"
-        generator = ipfsapi.multipart.BodyGenerator(name, disptype,
-                                                    subtype, boundary)
-        headers = ""
-        for chunk in generator.close():
-            if type(chunk) is not str:
-                chunk = chunk.decode()
-            headers += chunk
-        assert headers == expected
 
 
 def _generate_test_chunks(chunk_size, interations):
-    """Generates strings of chunk_size length until out of iterations."""
-    for i in range(interations):
-        output = b""
-        for j in range(chunk_size):
-            output += b"z"
-        yield output
+	"""Generates strings of chunk_size length until out of iterations."""
+	for i in range(interations):
+		output = b""
+		for j in range(chunk_size):
+			output += b"z"
+		yield output
 
 
-class TestBufferedGenerator(unittest.TestCase):
-    """Test the BufferedGenerator class.
+class StreamBaseSub(ipfsapi.multipart.StreamBase):
+	def _body(self):
+		raise NotImplementedError()
 
-    Public methods:
-    test_init -- test the default arguments of the constructor
-    test_file_chunks -- test the file_chunks function against example output
-    test_gen_chunks -- test the gen_chunks function against example output
-    test_body -- verify that body is unimplemented
-    test_close -- test the close function against example output
-    """
-
-    def test_init(self):
-        """Test the __init__ function for default parameter values."""
-        name = "test_name"
-        instance = ipfsapi.multipart.BufferedGenerator(name)
-        assert instance.name == name
-
-    def test_file_chunks(self):
-        """Test the file_chunks function against example output.
-
-        Warning: This test depends on the contents of
-        test/functional/fake_dir/fsdfgh
-        Changing that file could break the test.
-        """
-        name = "fsdfgh"
-        chunk_size = 2
-        path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                            "functional", "fake_dir", "fsdfgh")
-        instance = ipfsapi.multipart.BufferedGenerator(name, chunk_size)
-        expected = 'dsadsad\n'
-        output = ""
-        open_file = open(path)
-        for emitted in instance.file_chunks(open_file):
-            if type(emitted) is not str:
-                emitted = emitted.decode()
-            assert len(emitted) <= chunk_size
-            output += emitted
-        open_file.close()
-        assert output == expected
-
-    def test_gen_chunks(self):
-        """Test the gen_chunks function against example output."""
-        name = "fsdfgh"
-        chunk_size = 2
-        instance = ipfsapi.multipart.BufferedGenerator(name, chunk_size)
-        for i in instance.gen_chunks(_generate_test_chunks(5, 5)):
-            assert len(i) <= chunk_size
-
-    def test_body(self):
-        """Ensure that body throws a NotImplemented exception."""
-        instance = ipfsapi.multipart.BufferedGenerator("name")
-        with pytest.raises(NotImplementedError):
-            instance.body()
-
-    def test_close(self):
-        """Test the close function against example output."""
-        name = "fsdfgh"
-        chunk_size = 2
-        instance = ipfsapi.multipart.BufferedGenerator(name, chunk_size)
-        expected = '--\S+--\r\n'
-        actual = ''
-        for i in instance.close():
-            if type(i) is not str and type(i) is not memoryview:
-                i = i.decode()
-            elif six.PY3 and type(i) is memoryview:
-                i = i.tobytes().decode()
-            assert len(i) <= chunk_size
-            actual += i
-
-        assert re.search(expected, actual)
+class StreamFileMixinSub(ipfsapi.multipart.StreamBase, ipfsapi.multipart.StreamFileMixin):
+	def _body(self):
+		raise NotImplementedError()
 
 
-class TestFileStream(unittest.TestCase):
-    """Test the FileStream class
+class TestStreamBase(unittest.TestCase):
+	"""Test the StreamBase class.
 
-    Public methods:
-    test_body -- check file stream body for proper structure
-    """
+	Public methods:
+	test_init -- test the default arguments of the constructor
+	test_init_defaults -- tests the constructor and its behavior with only the required argument
+	test_body -- verify that body is unimplemented
+	test__gen_headers -- tests _gen_headers function against example output
+	test__gen_item_start -- tests _gen_item_start function against example output
+	test__gen_chunks -- test the _gen_chunks function against example output
+	test__gen_end -- test the _gen_end function against example output
+	"""
 
-    def test_body(self):
-        """Test the body function against expected output.
+	def test_init(self):
+		"""Test the __init__ function for default parameter values."""
+		name = "test_name"
+		instance = StreamBaseSub(name)
+		assert instance.name == name
 
-        Warning: This test depends on the contents of
-        test/functional/fake_dir
-        Changing that directory or its contents could break the test.
-        """
-        # Get OS-agnostic path to test files
-        path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                            "functional", "fake_dir")
-        # Collect absolute paths to all test files
-        filenames_list = []
-        for (dirpath, _, filenames) in os.walk(path):
-            temp_list = [os.path.join(dirpath, name) for name in filenames]
-            filenames_list.extend(temp_list)
-        # Convert absolute paths to relative
-        relative_paths_list = [os.path.relpath(cur_path, os.getcwd())
-                               for cur_path in filenames_list]
+	def test_init_defaults(self):
+		"""Test the __init__ function for default parameter values."""
+		name = "test_name"
+		expected_disposition = 'form-data; filename="test_name"'
+		expected_type = 'multipart/form-data; boundary="\S*"'
+		expected_boundary_pattern = '\S*'
+		generator = StreamBaseSub(name)
+		assert generator._headers['Content-Disposition'] == expected_disposition
+		assert re.search(expected_type,             generator.headers()['Content-Type'])
+		assert re.search(expected_boundary_pattern, generator._boundary)
 
-        instance = ipfsapi.multipart.FileStream(relative_paths_list)
+	def test_body(self):
+		"""Ensure that body throws a NotImplemented exception."""
+		instance = StreamBaseSub("name")
+		with pytest.raises(NotImplementedError):
+			instance._body()
+			instance.body()
 
-        expected = "(--\S+\r\nContent-Disposition: file; filename=\"\S+\""\
-            + "\r\nContent-Type: application/\S+\r\n"\
-            + "\r\n(.|\n)*\r\n)+--\S+--\r\n"
-        actual = ""
-        for i in instance.body():
-            if type(i) is not str and type(i) is not memoryview:
-                i = i.decode()
-            elif six.PY3 and type(i) is memoryview:
-                i = i.tobytes().decode()
-            actual += i
-        assert re.search(expected, actual)
+	def test__gen_headers(self):
+		"""Test the _gen_headers function against sample output."""
+		name = "test_name"
+		generator = StreamBaseSub(name)
+
+		expected = b'Connection: close\r\n' \
+		         + b'Content-Disposition: form-data; filename="test_name"\r\n' \
+		         + b'Content-Type: multipart/form-data; ' \
+		         + b'boundary="' + generator._boundary.encode() + b'"\r\n\r\n'
+
+		headers = b"".join(generator._gen_headers(generator._headers))
+		assert headers == expected
+
+	def test__gen_item_start(self):
+		"""Test the _gen_item_start function against sample output."""
+		expected = b'--test_boundary\r\n'
+		name = "test_name"
+		generator = StreamBaseSub(name)
+		generator._boundary = "test_boundary"
+		headers = b"".join(generator._gen_item_start())
+		assert headers == expected
+
+	def test__gen_item_end(self):
+		"""Test the _gen_item_end function against sample output."""
+		expected = b"\r\n"
+		generator = StreamBaseSub("test")
+		headers = b"".join(generator._gen_item_end())
+		assert headers == expected
+
+	def test__gen_chunks(self):
+		"""Test the gen_chunks function against example output."""
+		name = "fsdfgh"
+		chunk_size = 2
+		instance = StreamBaseSub(name, chunk_size)
+		for i in instance._gen_chunks(_generate_test_chunks(5, 5)):
+			assert len(i) <= chunk_size
+
+	def test__gen_end(self):
+		"""Test the close function against example output."""
+		name = "fsdfgh"
+		instance = StreamBaseSub(name)
+		expected = b'--\S+--\r\n'
+		actual = b''
+		for i in instance._gen_end():
+			actual += i
+
+		assert re.search(expected, actual)
+
+
+class TestStreamFileMixin(unittest.TestCase):
+	"""Test the StreamFileMixin class.
+
+	Public methods:
+	test__gen_file -- test the _gen_file function against example output
+	test__gen_file_start -- test the _gen_file_start function against example output
+	test__gen_file_chunks -- test the _gen_file_chunks function against example output
+	test__gen_file_end -- test the _gen_file_end function against example output
+	"""
+
+	def test__gen_file(self):
+		"""Test the _gen_file function against sample output."""
+		name = "functional/fake_dir/fsdfgh"
+		generator = StreamFileMixinSub(name)
+
+		file = io.BytesIO()
+		file.write(b"!234")
+		file.seek(0)
+
+		expected = b'--' + generator._boundary.encode() + b'\r\nContent-Disposition: file; '\
+		         + b'filename="functional%2Ffake_dir%2Ffsdfgh"\r\nContent-Type: '\
+		         + b'text/plain\r\n\r\n' \
+		         + b'!234\r\n'
+
+		headers = b"".join(generator._gen_file(name, file, content_type="text/plain"))
+		assert headers == expected
+
+	def test__gen_file_start(self):
+		"""Test the _gen_file_start function against sample output."""
+		name = "test_name"
+		generator = StreamFileMixinSub(name)
+
+		expected = b'--' + generator._boundary.encode() + b'\r\nContent-Disposition: file; '\
+		         + b'filename="test_name"\r\nContent-Type: '\
+		         + b'application/octet-stream\r\n\r\n'
+
+		headers = b"".join(generator._gen_file_start(name))
+		assert headers == expected
+
+	def test__gen_file_chunks(self):
+		"""Test the _gen_file_chunks function against example output.
+
+		Warning: This test depends on the contents of
+		test/functional/fake_dir/fsdfgh
+		Changing that file could break the test.
+		"""
+		name = "fsdfgh"
+		chunk_size = 2
+		path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+		                    "functional", "fake_dir", "fsdfgh")
+		instance = StreamFileMixinSub(name, chunk_size)
+		expected = 'dsadsad\n'
+		output = ""
+		open_file = open(path)
+		for emitted in instance._gen_file_chunks(open_file):
+			if type(emitted) is not str:
+				emitted = emitted.decode()
+			assert len(emitted) <= chunk_size
+			output += emitted
+		open_file.close()
+		assert output == expected
+
+	def test__gen_file_end(self):
+		"""Test the _gen_file_end function against sample output."""
+		expected = b"\r\n"
+		generator = StreamFileMixinSub("test")
+		headers = b"".join(generator._gen_file_end())
+		assert headers == expected
+
+
+class TestFilesStream(unittest.TestCase):
+	"""Test the FileStream class
+
+	Public methods:
+	test_body -- check file stream body for proper structure
+	"""
+
+	def test_body(self):
+		"""Test the body function against expected output.
+
+		Warning: This test depends on the contents of
+		test/functional/fake_dir
+		Changing that directory or its contents could break the test.
+		"""
+		# Get OS-agnostic path to test files
+		path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+		                    "functional", "fake_dir")
+		# Collect absolute paths to all test files
+		filenames_list = []
+		for (dirpath, _, filenames) in os.walk(path):
+			temp_list = [os.path.join(dirpath, name) for name in filenames]
+			filenames_list.extend(temp_list)
+		# Convert absolute paths to relative
+		relative_paths_list = [os.path.relpath(cur_path, os.getcwd())
+		                       for cur_path in filenames_list]
+
+		instance = ipfsapi.multipart.FilesStream(relative_paths_list)
+
+		expected = "(--\S+\r\nContent-Disposition: file; filename=\"\S+\""\
+			+ "\r\nContent-Type: application/\S+\r\n"\
+			+ "\r\n(.|\n)*\r\n)+--\S+--\r\n"
+		actual = ""
+		for i in instance.body():
+			if type(i) is not str and type(i) is not memoryview:
+				i = i.decode()
+			elif six.PY3 and type(i) is memoryview:
+				i = i.tobytes().decode()
+			actual += i
+		assert re.search(expected, actual)
 
 
 class TestDirectoryStream(unittest.TestCase):
-    """Test the DirectoryStream class.
+	"""Test the DirectoryStream class.
 
-    Public methods:
-    test_body -- check that the HTTP body for the directory is correct
-    test_body_recursive -- check body structure when recursive directory
-                            is uploaded
-    """
+	Public methods:
+	test_body -- check that the HTTP body for the directory is correct
+	test_body_recursive -- check body structure when recursive directory
+							is uploaded
+	"""
 
-    def test_body(self):
-        """Check the multipart HTTP body for the streamed directory."""
-        # Get OS-agnostic path to test files
-        path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                            "functional", "fake_dir")
-        instance = ipfsapi.multipart.DirectoryStream(path)
-        expected = b"^(--\S+\r\nContent-Disposition: form-data; name=\"\S+\"; filename=\"\S+\""\
-            + b"\r\nContent-Type: application/\S+\r\n\r\n(.|\n)*"\
-            + b"\r\n)+--\S+--\r\n$"
-        actual = instance.body()
-        """
-        for i in instance.body():
-            if type(i) is not str and type(i) is not memoryview:
-                i = i.decode()
-            elif six.PY3 and type(i) is memoryview:
-                i = i.tobytes().decode()
-            actual += i
-        """
-        assert re.search(expected, actual)
+	def test_body(self):
+		"""Check the multipart HTTP body for the streamed directory."""
+		# Get OS-agnostic path to test files
+		path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+		                    "functional", "fake_dir")
+		instance = ipfsapi.multipart.DirectoryStream(path)
+		expected = b"^(--\S+\r\nContent-Disposition: file; filename=\"\S+\""\
+			+ b"\r\nContent-Type: application/\S+\r\n\r\n(.|\n)*"\
+			+ b"\r\n)+--\S+--\r\n$"
+		actual = b"".join(instance.body())
+		assert re.search(expected, actual)
 
 
-class TestTextStream(unittest.TestCase):
-    """Test the TextStream class.
+class TestBytesFileStream(unittest.TestCase):
+	"""Test the TextStream class.
 
-    Public methods:
-    test_body -- check that the HTTP body for the text is correct
-    """
+	Public methods:
+	test_body -- check that the HTTP body for the text is correct
+	"""
 
-    def test_body(self):
-        """Check the multipart HTTP body for the streamed directory."""
-        # Get OS-agnostic path to test files
-        text = "Here is some text for this test."
-        instance = ipfsapi.multipart.BytesStream(text)
-        expected = "(--\S+\r\nContent-Disposition: file; filename=\"\S+\""\
-            + "\r\nContent-Type: application/\S+\r\n"\
-            + "\r\n(.|\n)*\r\n)+--\S+--\r\n"
-        actual = ""
-        for i in instance.body():
-            if type(i) is not str and type(i) is not memoryview:
-                i = i.decode()
-            elif six.PY3 and type(i) is memoryview:
-                i = i.tobytes().decode()
-            actual += i
-        assert re.search(expected, actual)
+	def test_body(self):
+		"""Check the multipart HTTP body for the streamed directory."""
+		# Get OS-agnostic path to test files
+		text = b"Here is some text for this test."
+		instance = ipfsapi.multipart.BytesFileStream(text)
+		expected = b"(--\S+\r\nContent-Disposition: file; filename=\"\S+\""\
+			+ b"\r\nContent-Type: application/\S+\r\n"\
+			+ b"\r\n(.|\n)*\r\n)+--\S+--\r\n"
+		actual = b"".join(instance.body())
+		assert re.search(expected, actual)
 
 
 class TestStreamHelpers(unittest.TestCase):
-    """Test stream_files, stream_directory, and stream_text.
+	"""Test stream_files, stream_directory, and stream_text.
 
-    TODO: These functions are just wrappers around other,
-    already-tested functions. Maybe they should be tested,
-    but it is unclear how.
+	TODO: These functions are just wrappers around other,
+	already-tested functions. Maybe they should be tested,
+	but it is unclear how.
 
-    Public Methods:
-    test_stream_files -- unimplemented
-    test_stream_directory -- unimplemented
-    test_stream_text -- unimplemented
-    """
+	Public Methods:
+	test_stream_files -- unimplemented
+	test_stream_directory -- unimplemented
+	test_stream_text -- unimplemented
+	"""
 
-    def test_stream_files(self):
-        """Test the stream_files function."""
-        pass
+	def test_stream_files(self):
+		"""Test the stream_files function."""
+		pass
 
-    def test_stream_directory(self):
-        """Test the stream_directory function."""
-        pass
+	def test_stream_directory(self):
+		"""Test the stream_directory function."""
+		pass
 
-    def test_stream_text(self):
-        """Test the stream_text function."""
-        pass
+	def test_stream_text(self):
+		"""Test the stream_text function."""
+		pass

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -36,26 +36,6 @@ class TestUtils(unittest.TestCase):
                             "..", "..", "requirements.txt")
         assert utils.guess_mimetype(path) == "text/plain"
 
-    def test_ls_dir(self):
-        """Tests utils.ls_dir()
-
-        This test is dependent on the contents of the directory 'fake_dir'
-        located in 'test/functional' not being modified.
-        """
-        path = os.path.join(os.path.dirname(__file__),
-                            "..", "functional", "fake_dir")
-        dirs = ['test2', 'test3']
-        files = ['fsdfgh', 'popoiopiu']
-        contents = (files, dirs)
-        
-        # Sort items before comparing as the ordering of files returned by
-        # the file system is not stable
-        result = utils.ls_dir(path)
-        result[0].sort()
-        result[1].sort()
-        
-        assert result == contents
-
     def test_clean_file_opened(self):
         """Tests utils.clean_file() with a stringIO object."""
         string_io = io.StringIO(u'Mary had a little lamb')
@@ -111,16 +91,6 @@ class TestUtils(unittest.TestCase):
             # Closing files/stringIO objects after test assertions.
             tup[0].close()
 
-    def test_file_size(self):
-        """Tests utils.file_size().
-
-        This test relies on the content size of the file 'fsdfgh'
-        located in 'test/functional/fake_dir' not being modified.
-        """
-        path = os.path.join(os.path.dirname(__file__),
-                            "..", "functional", "fake_dir", "fsdfgh")
-        assert utils.file_size(path) == 8
-
     def test_return_field_init(self):
         """Tests utils.return_field.__init__()."""
         return_field = utils.return_field('Hash')
@@ -129,7 +99,7 @@ class TestUtils(unittest.TestCase):
     def test_return_field_call(self):
         """Tests utils.return_field.__call__()."""
         expected_hash = u'QmZfF6C9j4VtoCsTp4KSrhYH47QMd3DNXVZBKaxJdhaPab'
-        
+
         @utils.return_field('Hash')
         def wrapper(string, *args, **kwargs):
             resp = {'Hash': expected_hash, 'string': string}

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,19 @@ commands =
 	flake8 {posargs}
 
 [flake8]
-ignore = E222,E221,F403,E265
-exclude = .venv,.git,.tox,+junk,dist,doc,*egg,build,tools,test,docs,*__init__.py
+exclude = .git,.tox,+junk,dist,doc,*egg,build,tools,test,docs,*__init__.py
+
+# E221: Multiple spaces before operator
+# E222: Multiple spaces after operator
+# E262: Inline comment should start with '# ': Breaks tagged comments (ie: '#TODO: ')
+# E265: Block comment should start with '# ':  ^
+# E303: More than 2 consecutive newlines
+# W292: No newline at end of file
+# W391: Blank line at end of file (sometimes trigged instead of the above!?)
+# F403: `from <module> import *` used; unable to detect undefined names ←– Probably should be fixed…
+ignore = E221,E222,E262,E265,E303,W292,W391,F403
+max-line-length = 100
+tab-width = 4
 
 [pytest]
 python_files =
@@ -36,8 +47,7 @@ python_files =
 	*_test.py
 	tests.py
 addopts =
-	--doctest-modules
-	--ignore ipfsapi/client.py
+#   --doctest-modules / Totally useless since it cannot properly check the `client` package
 	ipfsapi
 	test/unit
 	test/functional

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,11 @@ ignore = E221,E222,E262,E265,E303,W292,W391,F403
 max-line-length = 100
 tab-width = 4
 
+# E701: Multiple statements on one line
+#  - multipart.py: Lots of `yield from` polyfills using `for chunk in X: yield chunk`
+per-file-ignores =
+	/ipfsapi/multipart.py: E701
+
 [pytest]
 python_files =
 	test_*.py


### PR DESCRIPTION
Fixes #104 and some other stuff. Also gets rid of `requests` in the multipart code making it framework agnostic again, while probably being more efficient, but definitely more resource aware:

  * Even when streaming large directory trees the maximum number of open fds should only be `tree_depth + 1` (one fd for each directory layer and one for the actual file in question)
  * Files are streamed from disk using generators so there should never be more than a couple of kilobytes of file data be present in RAM