### PR TITLE
Update documentation generator for new hierachical `Client` class

### DIFF
--- a/docs/http_client_ref.md
+++ b/docs/http_client_ref.md
@@ -24,8 +24,8 @@ All methods accept the following parameters in their ``kwargs``:
 
 .. autofunction:: ipfshttpclient.assert_version
 
-.. autoclass:: ipfshttpclient.Client
-    :members:
-    :show-inheritance:
-
+.. autoclientclass:: ipfshttpclient.Client
+	:members:
+	:inherited-members:
+	:undoc-members:
 ```

--- a/ipfshttpclient/client/base.py
+++ b/ipfshttpclient/client/base.py
@@ -8,18 +8,18 @@ from .. import multipart, http
 
 class SectionProperty(object):
 	def __init__(self, cls):
-		self.cls = cls
+		self.__prop_cls__ = cls
 
 	def __get__(self, client_object, type=None):
 		try:
 			return client_object.__prop_objs__[self]
 		except AttributeError:
 			client_object.__prop_objs__ = {
-				self: self.cls(client_object)
+				self: self.__prop_cls__(client_object)
 			}
 			return client_object.__prop_objs__[self]
 		except KeyError:
-			client_object.__prop_objs__[self] = self.cls(client_object)
+			client_object.__prop_objs__[self] = self.__prop_cls__(client_object)
 			return client_object.__prop_objs__[self]
 
 

--- a/ipfshttpclient/client/block.py
+++ b/ipfshttpclient/client/block.py
@@ -26,7 +26,7 @@ class Section(base.SectionBase):
 
 		Returns
 		-------
-			str : Value of the requested block
+			bytes : Value of the requested block
 		"""
 		args = (multihash,)
 		return self._client.request('/block/get', args, **kwargs)
@@ -43,7 +43,7 @@ class Section(base.SectionBase):
 
 		Parameters
 		----------
-		file : io.RawIOBase
+		file : Union[str, bytes, os.PathLike, io.IOBase, int]
 			The data to be stored as an IPFS block
 
 		Returns

--- a/ipfshttpclient/client/files.py
+++ b/ipfshttpclient/client/files.py
@@ -39,7 +39,7 @@ class Section(base.SectionBase):
 		source : str
 			Filepath within the MFS to copy from
 		dest : str
-			Destination filepath with the MFS to which the file will be
+			Destination filepath within the MFS to which the file will be
 			copied to
 		"""
 		args = (source, dest)
@@ -132,7 +132,7 @@ class Section(base.SectionBase):
 
 		Returns
 		-------
-			str : MFS file contents
+			bytes : MFS file contents
 		"""
 		opts = {"offset": offset}
 		if count is not None:
@@ -149,7 +149,6 @@ class Section(base.SectionBase):
 		.. code-block:: python
 
 			>>> client.files.rm("/bla/file")
-			b''
 
 		Parameters
 		----------
@@ -199,7 +198,7 @@ class Section(base.SectionBase):
 		----------
 		path : str
 			Filepath within the MFS
-		file : io.RawIOBase
+		file : Union[str, bytes, os.PathLike, io.RawIOBase, int]
 			IO stream object with data that should be written
 		offset : int
 			Byte offset at which to begin writing at
@@ -237,11 +236,11 @@ class Base(base.ClientBase):
 
 		Parameters
 		----------
-		files : str
+		files : Union[str, bytes, os.PathLike, int, io.IOBase, collections.abc.Iterable]
 			A filepath to either a file or directory
 		recursive : bool
-			Controls if files in subdirectories are added or not
-		pattern : str | list
+			Controls whether files in subdirectories are added or not
+		pattern : Union[str, list]
 			Single `*glob* <https://docs.python.org/3/library/glob.html>`_
 			pattern or list of *glob* patterns and compiled regular expressions
 			to match the names of the filepaths to keep
@@ -366,7 +365,7 @@ class Base(base.ClientBase):
 
 		Returns
 		-------
-			str : File contents
+			bytes : File contents
 		"""
 		args = (multihash,)
 		opts = {}

--- a/ipfshttpclient/client/files.py
+++ b/ipfshttpclient/client/files.py
@@ -88,7 +88,7 @@ class Section(base.SectionBase):
 			Create parent directories as needed and do not raise an exception
 			if the requested directory already exists
 		"""
-		kwargs.setdefault("opts", {"parents": parents})
+		kwargs.setdefault("opts", {})["parents"] = parents
 
 		args = (path,)
 		return self._client.request('/files/mkdir', args, **kwargs)
@@ -137,7 +137,7 @@ class Section(base.SectionBase):
 		opts = {"offset": offset}
 		if count is not None:
 			opts["count"] = count
-		kwargs.setdefault("opts", opts)
+		kwargs.setdefault("opts", {}).update(opts)
 
 		args = (path,)
 		return self._client.request('/files/read', args, **kwargs)
@@ -158,7 +158,7 @@ class Section(base.SectionBase):
 		recursive : bool
 			Recursively remove directories?
 		"""
-		kwargs.setdefault("opts", {"recursive": recursive})
+		kwargs.setdefault("opts", {})["recursive"] = recursive
 
 		args = (path,)
 		return self._client.request('/files/rm', args, **kwargs)
@@ -213,7 +213,7 @@ class Section(base.SectionBase):
 		opts = {"offset": offset, "create": create, "truncate": truncate}
 		if count is not None:
 			opts["count"] = count
-		kwargs.setdefault("opts", opts)
+		kwargs.setdefault("opts", {}).update(opts)
 
 		args = (path,)
 		body, headers = multipart.stream_files(file, self.chunk_size)
@@ -272,7 +272,7 @@ class Base(base.ClientBase):
 		}
 		if "chunker" in kwargs:
 			opts["chunker"] = kwargs.pop("chunker")
-		kwargs.setdefault("opts", opts)
+		kwargs.setdefault("opts", {}).update(opts)
 
 		body, headers = multipart.stream_filesystem_node(
 			files, recursive, pattern, self.chunk_size

--- a/ipfshttpclient/client/key.py
+++ b/ipfshttpclient/client/key.py
@@ -36,7 +36,7 @@ class Section(base.SectionBase):
 		"""
 
 		opts = {"type": type, "size": size}
-		kwargs.setdefault("opts", opts)
+		kwargs.setdefault("opts", {}).update(opts)
 		args = (key_name,)
 
 		return self._client.request('/key/gen', args, decoder='json', **kwargs)

--- a/ipfshttpclient/client/miscellaneous.py
+++ b/ipfshttpclient/client/miscellaneous.py
@@ -38,7 +38,7 @@ class Base(base.ClientBase):
 		-------
 			dict : Resource were a DNS entry points to
 		"""
-		kwargs.setdefault("opts", {"recursive": recursive})
+		kwargs.setdefault("opts", {})["recursive"] = recursive
 
 		args = (domain_name,)
 		return self._client.request('/dns', args, decoder='json', **kwargs)
@@ -112,7 +112,7 @@ class Base(base.ClientBase):
 		"""
 		#PY2: No support for kw-only parameters after glob parameters
 		if "count" in kwargs:
-			kwargs.setdefault("opts", {"count": kwargs["count"]})
+			kwargs.setdefault("opts", {})["count"] = kwargs["count"]
 			del kwargs["count"]
 		
 		args = (peer,) + peers
@@ -145,7 +145,7 @@ class Base(base.ClientBase):
 		-------
 			dict : IPFS path of resource
 		"""
-		kwargs.setdefault("opts", {"recursive": recursive})
+		kwargs.setdefault("opts", {})["recursive"] = recursive
 		
 		args = (name,)
 		return self._client.request('/resolve', args, decoder='json', **kwargs)

--- a/ipfshttpclient/client/name.py
+++ b/ipfshttpclient/client/name.py
@@ -50,7 +50,7 @@ class Section(base.SectionBase):
 			opts["ttl"] = ttl
 		if key:
 			opts["key"] = key
-		kwargs.setdefault("opts", opts)
+		kwargs.setdefault("opts", {}).update(opts)
 
 		args = (ipfs_path,)
 		return self._client.request('/name/publish', args, decoder='json', **kwargs)
@@ -81,6 +81,7 @@ class Section(base.SectionBase):
 		-------
 			dict : The IPFS path the IPNS hash points at
 		"""
-		kwargs.setdefault("opts", {"recursive": recursive, "nocache": nocache})
+		opts = {"recursive": recursive, "nocache": nocache}
+		kwargs.setdefault("opts", {}).update(opts)
 		args = (name,) if name is not None else ()
 		return self._client.request('/name/resolve', args, decoder='json', **kwargs)

--- a/ipfshttpclient/client/object.py
+++ b/ipfshttpclient/client/object.py
@@ -57,7 +57,7 @@ class PatchSection(base.SectionBase):
 		----------
 		multihash : str
 			The hash of an ipfs object to modify
-		new_data : io.RawIOBase
+		new_data : Union[str, bytes, os.PathLike, io.IOBase, int]
 			The data to append to the object's data section
 
 		Returns
@@ -116,7 +116,7 @@ class PatchSection(base.SectionBase):
 		----------
 		root : str
 			IPFS hash of the object to modify
-		data : io.RawIOBase
+		data : Union[str, bytes, os.PathLike, io.IOBase, int]
 			The new data to store in root
 
 		Returns
@@ -149,7 +149,7 @@ class Section(base.SectionBase):
 
 		Returns
 		-------
-			str : Raw object data
+			bytes : Raw object data
 		"""
 		args = (multihash,)
 		return self._client.request('/object/data', args, **kwargs)
@@ -157,7 +157,7 @@ class Section(base.SectionBase):
 
 	def get(self, multihash, **kwargs):
 		"""Get and serialize the DAG node named by multihash.
-
+		
 		.. code-block:: python
 
 			>>> client.object.get('QmTkzDwWqPbnAh5YiV5VwcTLnGdwSNsNTn2aDxdXBFca7D')
@@ -269,7 +269,7 @@ class Section(base.SectionBase):
 
 		Parameters
 		----------
-		file : io.RawIOBase
+		file : Union[str, bytes, os.PathLike, io.IOBase, int]
 			(JSON) object from which the DAG object will be created
 
 		Returns

--- a/ipfshttpclient/client/object.py
+++ b/ipfshttpclient/client/object.py
@@ -36,7 +36,7 @@ class PatchSection(base.SectionBase):
 		-------
 			dict : Hash of new object
 		"""
-		kwargs.setdefault("opts", {"create": create})
+		kwargs.setdefault("opts", {})["create"] = create
 
 		args = ((root, name, ref),)
 		return self._client.request('/object/patch/add-link', args, decoder='json', **kwargs)

--- a/ipfshttpclient/client/pin.py
+++ b/ipfshttpclient/client/pin.py
@@ -28,7 +28,7 @@ class Section(base.SectionBase):
 		"""
 		#PY2: No support for kw-only parameters after glob parameters
 		if "recursive" in kwargs:
-			kwargs.setdefault("opts", {"recursive": kwargs.pop("recursive")})
+			kwargs.setdefault("opts", {})["recursive"] = kwargs.pop("recursive")
 
 		args = (path,) + paths
 		return self._client.request('/pin/add', args, decoder='json', **kwargs)
@@ -65,7 +65,7 @@ class Section(base.SectionBase):
 		-------
 			dict : Hashes of pinned IPFS objects and why they are pinned
 		"""
-		kwargs.setdefault("opts", {"type": type})
+		kwargs.setdefault("opts", {})["type"] = type
 
 		return self._client.request('/pin/ls', decoder='json', **kwargs)
 
@@ -94,8 +94,7 @@ class Section(base.SectionBase):
 		"""
 		#PY2: No support for kw-only parameters after glob parameters
 		if "recursive" in kwargs:
-			kwargs.setdefault("opts", {"recursive": kwargs["recursive"]})
-			del kwargs["recursive"]
+			kwargs.setdefault("opts", {})["recursive"] = kwargs.pop("recursive")
 
 		args = (path,) + paths
 		return self._client.request('/pin/rm', args, decoder='json', **kwargs)
@@ -132,8 +131,7 @@ class Section(base.SectionBase):
 		"""
 		#PY2: No support for kw-only parameters after glob parameters
 		if "unpin" in kwargs:
-			kwargs.setdefault("opts", {"unpin": kwargs["unpin"]})
-			del kwargs["unpin"]
+			kwargs.setdefault("opts", {})["unpin"] = kwargs.pop("unpin")
 
 		args = (from_path, to_path)
 		return self._client.request('/pin/update', args, decoder='json', **kwargs)
@@ -175,8 +173,7 @@ class Section(base.SectionBase):
 		"""
 		#PY2: No support for kw-only parameters after glob parameters
 		if "verbose" in kwargs:
-			kwargs.setdefault("opts", {"verbose": kwargs["verbose"]})
-			del kwargs["verbose"]
+			kwargs.setdefault("opts", {})["verbose"] = kwargs.pop("verbose")
 
 		args = (path,) + paths
 		return self._client.request('/pin/verify', args, decoder='json', stream=True, **kwargs)

--- a/ipfshttpclient/client/unstable.py
+++ b/ipfshttpclient/client/unstable.py
@@ -12,7 +12,7 @@ class LogSection(base.SectionBase):
 		
 		.. code-block:: python
 
-			>>> client.log_level("path", "info")
+			>>> client.unstable.log.level("path", "info")
 			{'Message': "Changed log level of 'path' to 'info'\n"}
 
 		Parameters
@@ -44,7 +44,7 @@ class LogSection(base.SectionBase):
 		
 		.. code-block:: python
 
-			>>> client.log_ls()
+			>>> client.unstable.log.ls()
 			{'Strings': [
 				'github.com/ipfs/go-libp2p/p2p/host', 'net/identify',
 				'merkledag', 'providers', 'routing/record', 'chunk', 'mfs',
@@ -80,7 +80,7 @@ class LogSection(base.SectionBase):
 		
 		.. code-block:: python
 
-			>>> with client.log_tail() as log_tail_iter:
+			>>> with client.unstable.log.tail() as log_tail_iter:
 			...     for item in log_tail_iter:
 			...         print(item)
 			...

--- a/ipfshttpclient/encoding.py
+++ b/ipfshttpclient/encoding.py
@@ -267,7 +267,7 @@ class Json(Encoding):
 
         Parameters
         ----------
-        obj : str | list | dict | int
+        obj : Union[str, list, dict, int]
             JSON serializable Python object
 
         Returns

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -221,7 +221,7 @@ class HTTPClient(object):
             The REST command path to send
         args : list
             Positional parameters to be sent along with the HTTP request
-        files : :class:`io.RawIOBase` | :obj:`str` | :obj:`list`
+        files : Union[str, io.RawIOBase, collections.abc.Iterable]
             The file object(s) or path(s) to stream to the daemon
         opts : dict
             Query string paramters to be sent along with the HTTP request

--- a/ipfshttpclient/multipart.py
+++ b/ipfshttpclient/multipart.py
@@ -270,7 +270,7 @@ class FilesStream(StreamBase, StreamFileMixin):
 
 	Parameters
 	----------
-	files : str | bytes | os.PathLike | io.IOBase | int | collections.abc.Iterable
+	files : Union[str, bytes, os.PathLike, io.IOBase, int, collections.abc.Iterable]
 		The name, file object or file descriptor of the file to encode; may also
 		be a list of several items to allow for more efficient batch processing
 	chunk_size : int
@@ -359,14 +359,14 @@ class DirectoryStream(StreamBase, StreamFileMixin):
 
 	Parameters
 	----------
-	directory : str | os.PathLike | int
+	directory : Union[str, os.PathLike, int]
 		The filepath or file descriptor of the directory to encode
 
 		File descriptors are only supported on Unix and Python 3.
-	dirname : str | None
+	dirname : Union[str, None]
 		The name of the base directroy to upload, use ``None`` for
-		the default of ``os.path.basename(directory) || '.'``
-	patterns : str | re.compile | collections.abc.Iterable
+		the default of ``os.path.basename(directory) or '.'``
+	patterns : Union[str, re.compile, collections.abc.Iterable]
 		A single glob pattern or a list of several glob patterns and
 		compiled regular expressions used to determine which filepaths to match
 	chunk_size : int
@@ -578,7 +578,7 @@ def stream_files(files, chunk_size=default_chunk_size):
 
 	Parameters
 	----------
-	files : str | bytes | os.PathLike | io.IOBase | int | collections.abc.Iterable
+	files : Union[str, bytes, os.PathLike, io.IOBase, int, collections.abc.Iterable]
 		The file(s) to stream
 	chunk_size : int
 		Maximum size of each stream chunk
@@ -595,11 +595,11 @@ def stream_directory(directory, recursive=False, patterns='**', chunk_size=defau
 
 	Parameters
 	----------
-	directory : str | bytes | os.PathLike | int
+	directory : Union[str, bytes, os.PathLike, int]
 		The filepath of the directory to stream
 	recursive : bool
 		Stream all content within the directory recursively?
-	patterns : str | re.compile | collections.abc.Iterable
+	patterns : Union[str, re.compile, collections.abc.Iterable]
 		Single *glob* pattern or list of *glob* patterns and compiled
 		regular expressions to match the names of the filepaths to keep
 	chunk_size : int
@@ -642,11 +642,11 @@ def stream_filesystem_node(filepaths,
 
 	Parameters
 	----------
-	filepaths : str | bytes | os.PathLike | int | io.IOBase | collections.abc.Iterable
+	filepaths : Union[str, bytes, os.PathLike, int, io.IOBase, collections.abc.Iterable]
 		The filepath of a single directory or one or more files to stream
 	recursive : bool
 		Stream all content within the directory recursively?
-	patterns : str | re.compile | collections.abc.Iterable
+	patterns : Union[str, re.compile, collections.abc.Iterable]
 		Single *glob* pattern or list of *glob* patterns and compiled
 		regular expressions to match the paths of files and directories
 		to be added to IPFS (directories only)

--- a/ipfshttpclient/utils.py
+++ b/ipfshttpclient/utils.py
@@ -76,7 +76,7 @@ def clean_file(file):
 
     Parameters
     ----------
-    file : str | bytes | os.PathLike | io.IOBase | int
+    file : Union[str, bytes, os.PathLike, io.IOBase, int]
         A filepath or ``file``-like object that may or may not need to be
         opened
     """
@@ -101,7 +101,7 @@ def clean_files(files):
 
     Parameters
     ----------
-    files : str | bytes | os.PathLike | io.IOBase | int | collections.abc.Iterable
+    files : Union[str, bytes, os.PathLike, io.IOBase, int, collections.abc.Iterable]
         Collection or single instance of a filepath and file-like object
     """
     if not isinstance(files, path_types) and not hasattr(files, "read"):


### PR DESCRIPTION
The new [hierarchical `Client` class](https://github.com/ipfs/py-ipfs-api/commit/6a3827c4b73ddbbb8a156e1aab89918a950ceb2c) is something that the Sphinx autodoc simply does not understand. To remedy this PR adds a new plugin to our Sphinx configuration file that will automatically detect the relevant property objects and render them as sub-class in the output.

Additionally some miscellaneous miscellaneous documentation fixes were applied in several places.

TODO: Investigate whether [`Sphinx.add_autodoc_attrgetter`](http://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_autodoc_attrgetter) can be used to simplify and future-proof the plugin.