### PR TITLE
Make it part of the function declaration whether the given function returns only a single item or not

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -116,6 +116,7 @@ class Client(files.Base, miscellaneous.Base):
 	###########
 
 	@utils.return_field('Hash')
+	@base.returns_single_item
 	def add_bytes(self, data, **kwargs):
 		"""Adds a set of bytes as a file to IPFS.
 
@@ -140,6 +141,7 @@ class Client(files.Base, miscellaneous.Base):
 		                            data=body, headers=headers, **kwargs)
 
 	@utils.return_field('Hash')
+	@base.returns_single_item
 	def add_str(self, string, **kwargs):
 		"""Adds a Python string as a file to IPFS.
 
@@ -181,7 +183,9 @@ class Client(files.Base, miscellaneous.Base):
 			str : Hash of the added IPFS object
 		"""
 		return self.add_bytes(encoding.Json().encode(json_obj), **kwargs)
-
+	
+	
+	@base.returns_single_item
 	def get_json(self, cid, **kwargs):
 		"""Loads a json object from IPFS.
 

--- a/ipfshttpclient/client/base.py
+++ b/ipfshttpclient/client/base.py
@@ -1,9 +1,45 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import functools
+
+import six
 
 from . import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_BASE
 
 from .. import multipart, http
+
+
+def returns_single_item(func):
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		result = func(*args, **kwargs)
+		if isinstance(result, list):
+			if len(result) != 1:
+				print(result)
+			assert len(result) == 1, ("Called IPFS HTTP-Client function should "
+			                          "only ever return one item")
+			return result[0]
+		assert kwargs.get("stream", False), ("Called IPFS HTTP-Client function "
+		                                     "should only ever return a list, "
+		                                     "when not streaming a response")
+		return result
+	return wrapper
+
+
+def returns_no_item(func):
+	@functools.wraps(func)
+	def wrapper(*args, **kwargs):
+		result = func(*args, **kwargs)
+		if isinstance(result, (list, six.binary_type)):
+			assert len(result) == 0, ("Called IPFS HTTP-Client function should "
+			                          "never return an item")
+			return
+		assert kwargs.get("stream", False), ("Called IPFS HTTP-Client function "
+		                                     "should only ever return a list "
+		                                     "or bytes, when not streaming a "
+		                                     "response")
+		return result
+	return wrapper
 
 
 class SectionProperty(object):

--- a/ipfshttpclient/client/bitswap.py
+++ b/ipfshttpclient/client/bitswap.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def wantlist(self, peer=None, **kwargs):
 		"""Returns blocks currently on the bitswap wantlist.
 		
@@ -30,6 +31,7 @@ class Section(base.SectionBase):
 		return self._client.request('/bitswap/wantlist', args, decoder='json', **kwargs)
 	
 	
+	@base.returns_single_item
 	def stat(self, **kwargs):
 		"""Returns some diagnostic information from the bitswap agent.
 		

--- a/ipfshttpclient/client/block.py
+++ b/ipfshttpclient/client/block.py
@@ -30,8 +30,9 @@ class Section(base.SectionBase):
 		"""
 		args = (str(cid),)
 		return self._client.request('/block/get', args, **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def put(self, file, **kwargs):
 		"""Stores the contents of the given file object as an IPFS block.
 
@@ -55,8 +56,9 @@ class Section(base.SectionBase):
 		body, headers = multipart.stream_files(file, self.chunk_size)
 		return self._client.request('/block/put', decoder='json', data=body,
 		                            headers=headers, **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def stat(self, cid, **kwargs):
 		"""Returns a dict with the size of the block with the given hash.
 

--- a/ipfshttpclient/client/bootstrap.py
+++ b/ipfshttpclient/client/bootstrap.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def add(self, peer, *peers, **kwargs):
 		"""Adds peers to the bootstrap list.
 
@@ -19,8 +20,9 @@ class Section(base.SectionBase):
 		"""
 		args = (peer,) + peers
 		return self._client.request('/bootstrap/add', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def list(self, **kwargs):
 		"""Returns the addresses of peers used during initial discovery of the
 		IPFS network.
@@ -42,8 +44,9 @@ class Section(base.SectionBase):
 			dict : List of known bootstrap peers
 		"""
 		return self._client.request('/bootstrap', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def rm(self, peer, *peers, **kwargs):
 		"""Removes peers from the bootstrap list.
 

--- a/ipfshttpclient/client/config.py
+++ b/ipfshttpclient/client/config.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def get(self, **kwargs):
 		#TODO: Support the optional `key` parameter
 		"""Returns the current used server configuration.
@@ -29,8 +30,9 @@ class Section(base.SectionBase):
 			dict : The entire IPFS daemon configuration
 		"""
 		return self._client.request('/config/show', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def replace(self, config, **kwargs):
 		"""Replaces the existing config with a user-defined config.
 
@@ -38,8 +40,9 @@ class Section(base.SectionBase):
 		operation can't be undone.
 		"""
 		return self._client.request('/config/replace', (config,), decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def set(self, key, value=None, **kwargs):
 		"""Add or replace a configuration value.
 

--- a/ipfshttpclient/client/dht.py
+++ b/ipfshttpclient/client/dht.py
@@ -7,6 +7,7 @@ from .. import exceptions
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def findpeer(self, peer_id, *peer_ids, **kwargs):
 		"""Queries the DHT for all of the associated multiaddresses.
 
@@ -80,8 +81,9 @@ class Section(base.SectionBase):
 		"""
 		args = (str(cid),) + tuple(str(c) for c in cids)
 		return self._client.request('/dht/findprovs', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def get(self, key, *keys, **kwargs):
 		"""Queries the DHT for its best value related to given key.
 

--- a/ipfshttpclient/client/files.py
+++ b/ipfshttpclient/client/files.py
@@ -285,7 +285,7 @@ class Base(base.ClientBase):
 		kwargs.setdefault("opts", {}).update(opts)
 
 		assert not isinstance(file, (tuple, list)), \
-			"Use `client.add(name1, name2, …)` to add several items"
+		       "Use `client.add(name1, name2, …)` to add several items"
 		multiple = (len(files) > 0)
 		to_send  = ((file,) + files) if multiple else file
 		body, headers, is_dir = multipart.stream_filesystem_node(

--- a/ipfshttpclient/client/key.py
+++ b/ipfshttpclient/client/key.py
@@ -6,8 +6,9 @@ from . import base
 
 class Section(base.SectionBase):
 	#TODO: Add `export(name, password)`
-
-
+	
+	
+	@base.returns_single_item
 	def gen(self, key_name, type, size=2048, **kwargs):
 		"""Adds a new public key that can be used for
 		:meth:`~ipfshttpclient.Client.name.publish`.
@@ -45,6 +46,7 @@ class Section(base.SectionBase):
 	#TODO: Add `import(name, pam, password)`
 
 
+	@base.returns_single_item
 	def list(self, **kwargs):
 		"""Returns a list of generated public keys that can be used with
 		:meth:`~ipfshttpclient.Client.name.publish`.
@@ -52,19 +54,21 @@ class Section(base.SectionBase):
 		.. code-block:: python
 
 			>>> client.key.list()
-			{'Keys': [{'Name': 'self',
-					  'Id': 'QmQf22bZar3WKmojipms22PkXH1MZGmvsqzQtuSvQE3uhm'},
-					 {'Name': 'example_key_name',
-					  'Id': 'QmQLaT5ZrCfSkXTH6rUKtVidcxj8jrW3X2h75Lug1AV7g8'}
-					]}
+			{'Keys': [
+				{'Name': 'self',
+				 'Id': 'QmQf22bZar3WKmojipms22PkXH1MZGmvsqzQtuSvQE3uhm'},
+				{'Name': 'example_key_name',
+				 'Id': 'QmQLaT5ZrCfSkXTH6rUKtVidcxj8jrW3X2h75Lug1AV7g8'}
+			]}
 
 		Returns
 		-------
 			list : List of dictionaries with Names and Ids of public keys.
 		"""
 		return self._client.request('/key/list', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def rename(self, key_name, new_key_name, **kwargs):
 		"""Rename a keypair
 
@@ -91,8 +95,9 @@ class Section(base.SectionBase):
 		return self._client.request(
 			'/key/rename', args, decoder='json', **kwargs
 		)
-
-
+	
+	
+	@base.returns_single_item
 	def rm(self, key_name, *key_names, **kwargs):
 		"""Remove a keypair
 

--- a/ipfshttpclient/client/miscellaneous.py
+++ b/ipfshttpclient/client/miscellaneous.py
@@ -7,6 +7,7 @@ from .. import exceptions
 
 
 class Base(base.ClientBase):
+	@base.returns_single_item
 	def dns(self, domain_name, recursive=False, **kwargs):
 		"""Resolves DNS links to the referenced object.
 
@@ -44,6 +45,7 @@ class Base(base.ClientBase):
 		return self._client.request('/dns', args, decoder='json', **kwargs)
 	
 	
+	@base.returns_single_item
 	def id(self, peer=None, **kwargs):
 		"""Shows IPFS Node ID info.
 
@@ -83,8 +85,8 @@ class Base(base.ClientBase):
 
 
 	#TODO: isOnline()
-
-
+	
+	
 	def ping(self, peer, *peers, **kwargs):
 		"""Provides round-trip latency information for the routing system.
 		
@@ -118,6 +120,8 @@ class Base(base.ClientBase):
 		args = (peer,) + peers
 		return self._client.request('/ping', args, decoder='json', **kwargs)
 	
+	
+	@base.returns_single_item
 	def resolve(self, name, recursive=False, **kwargs):
 		"""Accepts an identifier and resolves it to the referenced item.
 		
@@ -151,6 +155,7 @@ class Base(base.ClientBase):
 		return self._client.request('/resolve', args, decoder='json', **kwargs)
 	
 	
+	@base.returns_no_item
 	def stop(self):
 		"""Stop the connected IPFS daemon instance.
 		
@@ -166,6 +171,7 @@ class Base(base.ClientBase):
 			pass
 	
 	
+	@base.returns_single_item
 	def version(self, **kwargs):
 		"""Returns the software version of the currently connected node.
 		

--- a/ipfshttpclient/client/name.py
+++ b/ipfshttpclient/client/name.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def publish(self, ipfs_path, resolve=True, lifetime="24h", ttl=None, key=None, **kwargs):
 		"""Publishes an object to IPNS.
 
@@ -55,8 +56,9 @@ class Section(base.SectionBase):
 
 		args = (ipfs_path,)
 		return self._client.request('/name/publish', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def resolve(self, name=None, recursive=False, nocache=False, **kwargs):
 		"""Gets the value currently published at an IPNS name.
 

--- a/ipfshttpclient/client/object.py
+++ b/ipfshttpclient/client/object.py
@@ -7,6 +7,7 @@ from .. import multipart
 
 
 class PatchSection(base.SectionBase):
+	@base.returns_single_item
 	def add_link(self, root, name, ref, create=False, **kwargs):
 		"""Creates a new merkledag object based on an existing one.
 
@@ -40,8 +41,9 @@ class PatchSection(base.SectionBase):
 
 		args = ((root, name, ref),)
 		return self._client.request('/object/patch/add-link', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def append_data(self, cid, new_data, **kwargs):
 		"""Creates a new merkledag object based on an existing one.
 
@@ -68,8 +70,9 @@ class PatchSection(base.SectionBase):
 		body, headers = multipart.stream_files(new_data, self.chunk_size)
 		return self._client.request('/object/patch/append-data', args, decoder='json',
 		                            data=body, headers=headers, **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def rm_link(self, root, link, **kwargs):
 		"""Creates a new merkledag object based on an existing one.
 
@@ -96,8 +99,9 @@ class PatchSection(base.SectionBase):
 		"""
 		args = ((root, link),)
 		return self._client.request('/object/patch/rm-link', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def set_data(self, root, data, **kwargs):
 		"""Creates a new merkledag object based on an existing one.
 
@@ -132,8 +136,8 @@ class PatchSection(base.SectionBase):
 
 class Section(base.SectionBase):
 	patch = base.SectionProperty(PatchSection)
-
-
+	
+	
 	def data(self, cid, **kwargs):
 		r"""Returns the raw bytes in an IPFS object.
 
@@ -153,8 +157,9 @@ class Section(base.SectionBase):
 		"""
 		args = (str(cid),)
 		return self._client.request('/object/data', args, **kwargs)
-
-
+	
+		
+	@base.returns_single_item
 	def get(self, cid, **kwargs):
 		"""Get and serialize the DAG node named by CID.
 		
@@ -185,8 +190,9 @@ class Section(base.SectionBase):
 		"""
 		args = (str(cid),)
 		return self._client.request('/object/get', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def links(self, cid, **kwargs):
 		"""Returns the links pointed to by the specified object.
 
@@ -217,8 +223,9 @@ class Section(base.SectionBase):
 		"""
 		args = (str(cid),)
 		return self._client.request('/object/links', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def new(self, template=None, **kwargs):
 		"""Creates a new object from an IPFS template.
 
@@ -244,8 +251,9 @@ class Section(base.SectionBase):
 		"""
 		args = (template,) if template is not None else ()
 		return self._client.request('/object/new', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def put(self, file, **kwargs):
 		"""Stores input as a DAG object and returns its key.
 
@@ -281,8 +289,9 @@ class Section(base.SectionBase):
 		body, headers = multipart.stream_files(file, self.chunk_size)
 		return self._client.request('/object/put', decoder='json', data=body,
 		                            headers=headers, **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def stat(self, cid, **kwargs):
 		"""Get stats for the DAG node named by cid.
 

--- a/ipfshttpclient/client/object.py
+++ b/ipfshttpclient/client/object.py
@@ -158,7 +158,7 @@ class Section(base.SectionBase):
 		args = (str(cid),)
 		return self._client.request('/object/data', args, **kwargs)
 	
-		
+	
 	@base.returns_single_item
 	def get(self, cid, **kwargs):
 		"""Get and serialize the DAG node named by CID.

--- a/ipfshttpclient/client/pin.py
+++ b/ipfshttpclient/client/pin.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def add(self, path, *paths, **kwargs):
 		"""Pins objects to local storage.
 
@@ -32,8 +33,9 @@ class Section(base.SectionBase):
 
 		args = (path,) + paths
 		return self._client.request('/pin/add', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def ls(self, type="all", **kwargs):
 		"""Lists objects pinned to local storage.
 
@@ -68,8 +70,9 @@ class Section(base.SectionBase):
 		kwargs.setdefault("opts", {})["type"] = type
 
 		return self._client.request('/pin/ls', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def rm(self, path, *paths, **kwargs):
 		"""Removes a pinned object from local storage.
 
@@ -98,8 +101,9 @@ class Section(base.SectionBase):
 
 		args = (path,) + paths
 		return self._client.request('/pin/rm', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def update(self, from_path, to_path, **kwargs):
 		"""Replaces one pin with another.
 

--- a/ipfshttpclient/client/pubsub.py
+++ b/ipfshttpclient/client/pubsub.py
@@ -29,6 +29,7 @@ class SubChannel:
 
 
 class Section(base.SectionBase):
+	@base.returns_single_item
 	def ls(self, **kwargs):
 		"""Lists subscribed topics by name
 
@@ -51,8 +52,9 @@ class Section(base.SectionBase):
 				   topics we are subscribed to
 		"""
 		return self._client.request('/pubsub/ls', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def peers(self, topic=None, **kwargs):
 		"""List the peers we are pubsubbing with.
 
@@ -101,8 +103,9 @@ class Section(base.SectionBase):
 		"""
 		args = (topic,) if topic is not None else ()
 		return self._client.request('/pubsub/peers', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_no_item
 	def publish(self, topic, payload, **kwargs):
 		"""Publish a message to a given pubsub topic
 
@@ -130,8 +133,8 @@ class Section(base.SectionBase):
 		"""
 		args = (topic, payload)
 		return self._client.request('/pubsub/pub', args, decoder='json', **kwargs)
-
-
+	
+	
 	def subscribe(self, topic, discover=False, **kwargs):
 		"""Subscribe to mesages on a given topic
 

--- a/ipfshttpclient/client/repo.py
+++ b/ipfshttpclient/client/repo.py
@@ -27,8 +27,9 @@ class Section(base.SectionBase):
 			dict : List of IPFS objects that have been removed
 		"""
 		return self._client.request('/repo/gc', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def stat(self, **kwargs):
 		"""Displays the repo's status.
 

--- a/ipfshttpclient/client/swarm.py
+++ b/ipfshttpclient/client/swarm.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class FiltersSection(base.SectionBase):
+	@base.returns_single_item
 	def add(self, address, *addresses, **kwargs):
 		"""Adds a given multiaddr filter to the filter list.
 
@@ -28,8 +29,9 @@ class FiltersSection(base.SectionBase):
 		"""
 		args = (address,) + addresses
 		return self._client.request('/swarm/filters/add', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def rm(self, address, *addresses, **kwargs):
 		"""Removes a given multiaddr filter from the filter list.
 
@@ -57,8 +59,9 @@ class FiltersSection(base.SectionBase):
 
 class Section(base.SectionBase):
 	filters = base.SectionProperty(FiltersSection)
-
-
+	
+	
+	@base.returns_single_item
 	def addrs(self, **kwargs):
 		"""Returns the addresses of currently connected peers by peer id.
 
@@ -91,8 +94,9 @@ class Section(base.SectionBase):
 			dict : Multiaddrs of peers by peer id
 		"""
 		return self._client.request('/swarm/addrs', decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def connect(self, address, *addresses, **kwargs):
 		"""Opens a connection to a given address.
 
@@ -117,8 +121,9 @@ class Section(base.SectionBase):
 		"""
 		args = (address,) + addresses
 		return self._client.request('/swarm/connect', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def disconnect(self, address, *addresses, **kwargs):
 		"""Closes the connection to a given address.
 
@@ -146,8 +151,9 @@ class Section(base.SectionBase):
 		"""
 		args = (address,) + addresses
 		return self._client.request('/swarm/disconnect', args, decoder='json', **kwargs)
-
-
+	
+	
+	@base.returns_single_item
 	def peers(self, **kwargs):
 		"""Returns the addresses & IDs of currently connected peers.
 

--- a/ipfshttpclient/client/unstable.py
+++ b/ipfshttpclient/client/unstable.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class LogSection(base.SectionBase):
+	@base.returns_single_item
 	def level(self, subsystem, level, **kwargs):
 		r"""Changes the logging output of a running daemon.
 		
@@ -36,7 +37,9 @@ class LogSection(base.SectionBase):
 		args = (subsystem, level)
 		return self._client.request('/log/level', args,
 		                            decoder='json', **kwargs)
-
+	
+	
+	@base.returns_single_item
 	def ls(self, **kwargs):
 		"""Lists the logging subsystems of a running daemon.
 		
@@ -69,7 +72,8 @@ class LogSection(base.SectionBase):
 			dict : List of daemon logging subsystems
 		"""
 		return self._client.request('/log/ls', decoder='json', **kwargs)
-
+	
+	
 	def tail(self, **kwargs):
 		r"""Reads log outputs as they are written.
 		

--- a/ipfshttpclient/encoding.py
+++ b/ipfshttpclient/encoding.py
@@ -22,6 +22,8 @@ class Encoding(object):
     """
     __metaclass__ = abc.ABCMeta
 
+    is_stream = False
+
     @abc.abstractmethod
     def parse_partial(self, raw):
         """Parses the given data and yields all complete data sets that can
@@ -94,6 +96,7 @@ class Dummy(Encoding):
     """Dummy parser/encoder that does nothing.
     """
     name = "none"
+    is_stream = True
 
     def parse_partial(self, raw):
         """Yields the data passed into this method.

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -120,23 +120,14 @@ class StreamDecodeIterator(object):
 
 def stream_decode_full(response, parser):
 	with StreamDecodeIterator(response, parser) as response_iter:
+		# Collect all responses
 		result = list(response_iter)
-
-		# Detect late error messages that occured after some data has already
-		# been sent
-		if len(result) > 0 \
-		and isinstance(result[-1], dict) \
-		and result[-1].get("Type") == "error":
-			msg = result[-1]["Message"]
-			partial = result[0:-2]
-			raise exceptions.PartialErrorResponse(msg, None, partial)
-
-		if len(result) == 0:
-			return b''
-		if len(result) == 1:
-			return result[0]
-		else:
-			return result
+		
+		# Return byte streams concatenated into one message, instead of split
+		# at arbitrary boundaries
+		if parser.is_stream:
+			return b"".join(result)
+		return result
 
 
 class HTTPClient(object):

--- a/ipfshttpclient/multipart.py
+++ b/ipfshttpclient/multipart.py
@@ -660,9 +660,9 @@ def stream_filesystem_node(filepaths,
 		import stat
 		is_dir = stat.S_ISDIR(os.fstat(filepaths).st_mode)
 	if is_dir:
-		return stream_directory(filepaths, recursive, patterns, chunk_size)
+		return stream_directory(filepaths, recursive, patterns, chunk_size) + (True,)
 	else:
-		return stream_files(filepaths, chunk_size)
+		return stream_files(filepaths, chunk_size) + (False,)
 
 
 def stream_bytes(data, chunk_size=default_chunk_size):

--- a/ipfshttpclient/multipart.py
+++ b/ipfshttpclient/multipart.py
@@ -659,7 +659,7 @@ def stream_filesystem_node(filepaths,
 	elif isinstance(filepaths, int):
 		import stat
 		is_dir = stat.S_ISDIR(os.fstat(filepaths).st_mode)
-	if recursive or is_dir:
+	if is_dir:
 		return stream_directory(filepaths, recursive, patterns, chunk_size)
 	else:
 		return stream_files(filepaths, chunk_size)

--- a/requirements-codestyle.txt
+++ b/requirements-codestyle.txt
@@ -1,2 +1,2 @@
 flake8~=3.7
-flake8-tabs~=1.0.1
+flake8-tabs~=2.0.0

--- a/test/functional/test_files.py
+++ b/test/functional/test_files.py
@@ -128,7 +128,7 @@ def test_only_hash_file(client):
 
 
 def test_add_multiple_from_list(client, cleanup_pins):
-	res = client.add([FAKE_FILE1_PATH, FAKE_FILE2_PATH])
+	res = client.add(FAKE_FILE1_PATH, FAKE_FILE2_PATH)
 	assert FAKE_FILES_HASH == res
 
 

--- a/test/unit/test_http.py
+++ b/test/unit/test_http.py
@@ -196,7 +196,7 @@ def test_explicit_decoder(http_client):
 	"""Tests that an explicit decoder is handled correctly."""
 	with HTTMock(http_client_okay):
 		res = http_client.request("/http_client_okay", decoder="json")
-		assert res["Message"] == "okay"
+		assert res[0]["Message"] == "okay"
 
 def test_unsupported_decoder(http_client):
 	"""Tests that unsupported encodings raise an exception."""

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ exclude = .git,.tox,+junk,coverage,dist,doc,*egg,build,tools,test/unit,docs,*__i
 # W391: Blank line at end of file (sometimes trigged instead of the above!?)
 # F403: `from <module> import *` used; unable to detect undefined names ←– Probably should be fixed…
 ignore = E221,E241,E262,E265,E266,E303,W292,W391,F403
+use-flake8-tabs = true
 max-line-length = 100
 tab-width = 4
 


### PR DESCRIPTION
Previously the code would rely on a heuristic where it would return only a single item if the daemon only returned one item, a list otherwise. This could have unexpected results in some cases (#133).

`.add()` is a special case, as it will only return a single item if a single *regular file* (but not directory) was added. It's parameter list was also changed so that adding several items now means passing several positional parameters, instead of a single parameter containing a list.

Along with #166 this closes #133 