### PR TITLE
Add timeout option

### DIFF
--- a/docs/http_client_ref.md
+++ b/docs/http_client_ref.md
@@ -18,6 +18,8 @@ All methods accept the following parameters in their ``kwargs``:
 
  * **opts** (*dict*) – A dictionary of custom parameters to be sent with the
                        HTTP request
+ * **timeout** (**float**) – The number of seconds to wait of a daemon reply
+                             before giving up
 
 ```eval_rst
 .. autofunction:: ipfshttpclient.connect

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -165,12 +165,12 @@ class HTTPClient(object):
                 return self._session.request(*args, **kwargs)
             else:
                 return requests.request(*args, **kwargs)
+        except (requests.ConnectTimeout, requests.Timeout) as error:
+            six.raise_from(exceptions.TimeoutError(error), error)
         except requests.ConnectionError as error:
             six.raise_from(exceptions.ConnectionError(error), error)
         except http_client.HTTPException as error:
             six.raise_from(exceptions.ProtocolError(error), error)
-        except requests.Timeout as error:
-            six.raise_from(exceptions.TimeoutError(error), error)
 
     def _do_raise_for_status(self, response):
         try:
@@ -197,10 +197,10 @@ class HTTPClient(object):
                 six.raise_from(exceptions.StatusError(error), error)
 
     def _request(self, method, url, params, parser, stream=False, files=None,
-                 headers={}, data=None):
+                 headers={}, data=None, timeout=120):
         # Do HTTP request (synchronously)
         res = self._do_request(method, url, params=params, stream=stream,
-                               files=files, headers=headers, data=data)
+                               files=files, headers=headers, data=data, timeout=timeout)
 
         # Raise exception for response status
         # (optionally incorpating the response message, if applicable)
@@ -216,7 +216,7 @@ class HTTPClient(object):
     @pass_defaults
     def request(self, path,
                 args=[], files=[], opts={}, stream=False,
-                decoder=None, headers={}, data=None):
+                decoder=None, headers={}, data=None, timeout=120):
         """Makes an HTTP request to the IPFS daemon.
 
         This function returns the contents of the HTTP response from the IPFS
@@ -242,6 +242,11 @@ class HTTPClient(object):
             Query string paramters to be sent along with the HTTP request
         decoder : str
             The encoder to use to parse the HTTP response
+        timeout : float
+            How many seconds to wait for the server to send data
+            before giving up
+            
+            Defaults to 120
         kwargs : dict
             Additional arguments to pass to :mod:`requests`
         """
@@ -259,11 +264,11 @@ class HTTPClient(object):
         parser = encoding.get_encoding(decoder if decoder else "none")
 
         return self._request(method, url, params, parser, stream,
-                             files, headers, data)
+                             files, headers, data, timeout=timeout)
 
     @pass_defaults
     def download(self, path, args=[], filepath=None, opts={},
-                 compress=True, **kwargs):
+                 compress=True, timeout=120, **kwargs):
         """Makes a request to the IPFS daemon to download a file.
 
         Downloads a file or files from IPFS into the current working
@@ -292,6 +297,11 @@ class HTTPClient(object):
         compress : bool
             Whether the downloaded file should be GZip compressed by the
             daemon before being sent to the client
+        timeout : float
+            How many seconds to wait for the server to send data
+            before giving up
+            
+            Defaults to 120
         kwargs : dict
             Additional arguments to pass to :mod:`requests`
         """
@@ -312,7 +322,7 @@ class HTTPClient(object):
         method = 'get'
 
         res = self._do_request(method, url, params=params, stream=True,
-                               **kwargs)
+                               timeout=timeout, **kwargs)
 
         self._do_raise_for_status(res)
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,7 +1,7 @@
-httmock ~= 1.3
 pathlib ; python_version < "3.4"
 pytest ~= 4.2
 pytest-cov ~= 2.6
+pytest-localserver ~= 0.5
 pytest-mock ~= 1.10
 pytest-ordering ~= 0.6
 

--- a/test/functional/test_block.py
+++ b/test/functional/test_block.py
@@ -3,20 +3,19 @@ try:
 	import cid
 except ImportError:
 	cid = None
+import io
 import pytest
 
 import conftest
 
+TEST1_FILEPATH = conftest.TEST_DIR / "fake_dir" / "fsdfgh"
+TEST1_CID_STR  = "QmPevo2B1pwvDyuZyJbWVfhwkaGPee3f1kX36wFmqx1yna"
+TEST1_SIZE     = 8
 
-TEST_CID_STR      = "QmYA2fn8cMbVWo4v95RwcwJVyQsNtnEwHerfWR8UNtEwoE"
-TEST_CONTENT_SIZE = 248
-
-if cid:
-	TEST2_CID_OBJ      = cid.make_cid("zb2rhjVFJv14KMc6qNirigEvFW8MWmpH1PMGYGi4BtqtLeS9z")
-	TEST2_CONTENT_SIZE = 13
-
-TEST_PUT_FILEPATH = conftest.TEST_DIR / "fake_dir" / "fsdfgh"
-TEST_PUT_CID      = "QmPevo2B1pwvDyuZyJbWVfhwkaGPee3f1kX36wFmqx1yna"
+TEST2_CONTENT = b"Hello World!"
+TEST2_CID_STR = "zb2rhfE3SX3q7Ha6UErfMqQReKsmLn73BvdDRagHDM6X1eRFN"
+TEST2_CID_OBJ = cid.make_cid(TEST2_CID_STR) if cid else None
+TEST2_SIZE    = len(TEST2_CONTENT)
 
 
 # Uncomment this if you don't want to wait for the `test_start` test during development:
@@ -24,23 +23,33 @@ TEST_PUT_CID      = "QmPevo2B1pwvDyuZyJbWVfhwkaGPee3f1kX36wFmqx1yna"
 #pytest.skip("TEMP!", allow_module_level=True)
 
 
+def test_put(client):
+	expected_keys = {"Key", "Size"}
+	res = client.block.put(TEST1_FILEPATH)
+	assert set(res.keys()).issuperset(expected_keys)
+	assert res["Key"] == TEST1_CID_STR
+
+
+@pytest.mark.run(after="test_put")
 def test_stat(client):
 	expected_keys = {"Key", "Size"}
-	res = client.block.stat(TEST_CID_STR)
+	res = client.block.stat(TEST1_CID_STR)
 	assert set(res.keys()).issuperset(expected_keys)
 
 
+@pytest.mark.run(after="test_put")
 def test_get(client):
-	assert len(client.block.get(TEST_CID_STR)) == TEST_CONTENT_SIZE
+	assert len(client.block.get(TEST1_CID_STR)) == TEST1_SIZE
+
+
+def test_put_str(client):
+	expected_keys = {"Key", "Size"}
+	res = client.block.put(io.BytesIO(TEST2_CONTENT), opts={"format": "raw"})
+	assert set(res.keys()).issuperset(expected_keys)
+	assert res["Key"] == TEST2_CID_STR
 
 
 @pytest.mark.skipif(not cid, reason="requires py-cid (Python 3.5+ only)")
+@pytest.mark.run(after="test_put_str")
 def test_stat_cid_obj(client):
-	assert len(client.block.get(TEST2_CID_OBJ)) == TEST2_CONTENT_SIZE
-
-
-def test_put(client):
-	expected_keys = {"Key", "Size"}
-	res = client.block.put(TEST_PUT_FILEPATH)
-	assert set(res.keys()).issuperset(expected_keys)
-	assert res["Key"] == TEST_PUT_CID
+	assert len(client.block.get(TEST2_CID_OBJ)) == TEST2_SIZE

--- a/test/unit/test_encoding.py
+++ b/test/unit/test_encoding.py
@@ -9,7 +9,6 @@ import json
 
 import pytest
 import six
-from httmock import urlmatch, HTTMock
 
 import ipfshttpclient.encoding
 import ipfshttpclient.exceptions

--- a/test/unit/test_http.py
+++ b/test/unit/test_http.py
@@ -9,203 +9,119 @@ TestHttp -- A TCP client for interacting with an IPFS daemon
 
 import json
 
-from httmock import urlmatch, HTTMock
 import pytest
+import pytest_localserver.http
 
 import ipfshttpclient.http
 import ipfshttpclient.exceptions
 
 
-HOST = "localhost"
-PORT = 5001
-NETLOC = "{0}:{1}".format(HOST, PORT)
+
+@pytest.fixture(scope="module")
+def http_server(request):
+	"""
+	Slightly modified version of the ``pytest_localserver.plugin.http_server``
+	fixture that will only start and stop the server application once for test
+	performance reasons.
+	"""
+	server = pytest_localserver.http.ContentServer()
+	server.start()
+	request.addfinalizer(server.stop)
+	return server
 
 
 @pytest.fixture
-def http_client():
+def http_client(http_server):
 	return ipfshttpclient.http.HTTPClient(
-		HOST, PORT, ipfshttpclient.DEFAULT_BASE
+		*(http_server.server_address + (ipfshttpclient.DEFAULT_BASE,))
 	)
 
 
-@urlmatch(netloc=NETLOC, path=r".*/okay")
-def return_okay(url, request):
-	"""Defines an endpoint for successful http requests.
 
-	This endpoint will listen at http://localhost:5001/*/okay for incoming
-	requests and will always respond with a 200 status code and a Message of
-	"okay".
-
-	Keyword arguments:
-	url -- the url of the incoming request
-	request -- the request that is being responded to
-	"""
-	return {
-		"status_code": 200,
-		"content": "okay".encode("utf-8"),
-	}
-
-
-@urlmatch(netloc=NETLOC, path=r".*/fail")
-def return_fail(url, request):
-	"""Defines an endpoint for failed http requests.
-
-	This endpoint will listen at http://localhost:5001/*/fail for incoming
-	requests and will always respond with a 500 status code and a Message of
-	"fail".
-
-	Keyword arguments:
-	url -- the url of the incoming request
-	request -- the request that is being responded to
-	"""
-	return {
-		"status_code": 500,
-		"content": "fail".encode("utf-8"),
-	}
-
-
-@urlmatch(netloc=NETLOC, path=r".*/http_client_okay")
-def http_client_okay(url, request):
-	"""Defines an endpoint for successful http client requests.
-
-	This endpoint will listen at http://localhost:5001/*/http_client_okay for incoming
-	requests and will always respond with a 200 status code and a json encoded
-	Message of "okay".
-
-	Keyword arguments:
-	url -- the url of the incoming request
-	request -- the request that is being responded to
-	"""
-	return {
-		"status_code": 200,
-		"content": json.dumps({
-			"Message": "okay"
-		}).encode("utf-8")
-	}
-
-
-@urlmatch(netloc=NETLOC, path=r".*/http_client_fail")
-def http_client_fail(url, request):
-	"""Defines an endpoint for failed http client requests.
-
-	This endpoint will listen at http://localhost:5001/*/http_client_fail for incoming
-	requests and will always respond with a 500 status code and a json encoded
-	Message of "Someone set us up the bomb".
-
-	Keyword arguments:
-	url -- the url of the incoming request
-	request -- the request that is being responded to
-	"""
-	return {
-		"status_code": 500,
-		"content": json.dumps({
-			"Message": "Someone set us up the bomb"
-		}).encode("utf-8")
-	}
-
-
-
-@urlmatch(netloc=NETLOC, path=r'.*/http_client_fail_late')
-def http_client_fail_late(url, request):
-	"""Defines an endpoint for successful http client requests.
-
-	This endpoint will listen at http://localhost:5001/*/http_client_fail_late
-	for incoming requests and will always respond with a 200 status code, a
-	json encoded Message of "okay", followed by a late error message.
-
-	Keyword arguments:
-	url -- the url of the incoming request
-	request -- the request that is being responded to
-	"""
-	return {
-		"status_code": 200,
-		"content": json.dumps({
-			"Message": "okay"
-		}).encode("utf-8") + b"\n" + json.dumps({
-			"Type":    "error",
-			"Message": "request failed after all"
-		}).encode("utf-8")
-	}
-
-@urlmatch(netloc=NETLOC, path=r".*/cat")
-def http_client_cat(url, request):
-	"""Defines an endpoint for a request to cat a file.
-
-	This endpoint will listen at http://localhost:5001/*/cat for incoming
-	requests and will always respond with a 200 status code and a json encoded
-	Message of "do not parse".
-
-	Keyword arguments:
-	url -- the url of the incoming request
-	request -- the request that is being responded to
-	"""
-	return {
-		"status_code": 200,
-		"content": json.dumps({
-			"Message": "do not parse"
-		}).encode("utf-8")
-	}
-
-
-def test_successful_request(http_client):
+def test_successful_request(http_client, http_server):
 	"""Tests that a successful http request returns the proper message."""
-	with HTTMock(return_okay):
-		res = http_client.request("/okay")
-		assert res == b"okay"
+	http_server.serve_content("okay", 200)
+	
+	res = http_client.request("/okay")
+	assert res == b"okay"
 
-def test_generic_failure(http_client):
+def test_generic_failure(http_client, http_server):
 	"""Tests that a failed http request raises an HTTPError."""
-	with HTTMock(return_fail):
-		with pytest.raises(ipfshttpclient.exceptions.StatusError):
-			http_client.request("/fail")
+	http_server.serve_content("fail", 500)
+	
+	with pytest.raises(ipfshttpclient.exceptions.StatusError):
+		http_client.request("/fail")
 
-def test_http_client_failure(http_client):
+def test_http_client_failure(http_client, http_server):
 	"""Tests that an http client failure raises an ipfsHTTPClientError."""
-	with HTTMock(http_client_fail):
-		with pytest.raises(ipfshttpclient.exceptions.ErrorResponse):
-			http_client.request("/http_client_fail")
+	http_server.serve_content(json.dumps({
+		"Message": "Someone set us up the bomb"
+	}), 500)
+	
+	with pytest.raises(ipfshttpclient.exceptions.ErrorResponse):
+		http_client.request("/http_client_fail")
 
-def test_http_client_late_failure(http_client):
+def test_http_client_late_failure(http_client, http_server):
 	"""Tests that an http client failure raises an ipfsHTTPClientError."""
-	with HTTMock(http_client_fail_late):
-		with pytest.raises(ipfshttpclient.exceptions.PartialErrorResponse):
-			http_client.request("/http_client_fail_late", decoder="json")
+	http_server.serve_content(json.dumps({
+		"Message": "okay"
+	}) + "\n" + json.dumps({
+		"Type":    "error",
+		"Message": "request failed after all"
+	}), 200)
+	
+	with pytest.raises(ipfshttpclient.exceptions.PartialErrorResponse):
+		http_client.request("/http_client_fail_late", decoder="json")
 
-def test_stream(http_client):
+def test_stream(http_client, http_server):
 	"""Tests that the stream flag being set returns the raw response."""
-	with HTTMock(return_okay):
-		res = http_client.request("/okay", stream=True)
-		assert next(res) == b"okay"
+	http_server.serve_content("okay", 200)
+	
+	res = http_client.request("/okay", stream=True)
+	assert next(res) == b"okay"
 
-def test_cat(http_client):
+def test_cat(http_client, http_server):
 	"""Tests that paths ending in /cat are not parsed."""
-	with HTTMock(http_client_cat):
-		res = http_client.request("/cat")
-		assert res == b'{"Message": "do not parse"}'
+	http_server.serve_content(json.dumps({
+		"Message": "do not parse"
+	}), 200)
+	
+	res = http_client.request("/cat")
+	assert res == b'{"Message": "do not parse"}'
 
-def test_default_decoder(http_client):
+def test_default_decoder(http_client, http_server):
 	"""Tests that the default encoding is set to json."""
-	with HTTMock(http_client_okay):
-		res = http_client.request("/http_client_okay")
-		assert res == b'{"Message": "okay"}'
+	http_server.serve_content(json.dumps({
+		"Message": "okay"
+	}), 200)
+	
+	res = http_client.request("/http_client_okay")
+	assert res == b'{"Message": "okay"}'
 
-def test_explicit_decoder(http_client):
+def test_explicit_decoder(http_client, http_server):
 	"""Tests that an explicit decoder is handled correctly."""
-	with HTTMock(http_client_okay):
-		res = http_client.request("/http_client_okay", decoder="json")
-		assert res[0]["Message"] == "okay"
+	http_server.serve_content(json.dumps({
+		"Message": "okay"
+	}), 200)
+	
+	res = http_client.request("/http_client_okay", decoder="json")
+	assert res[0]["Message"] == "okay"
 
-def test_unsupported_decoder(http_client):
+def test_unsupported_decoder(http_client, http_server):
 	"""Tests that unsupported encodings raise an exception."""
-	with HTTMock(http_client_fail):
-		with pytest.raises(ipfshttpclient.exceptions.EncoderMissingError):
-			http_client.request("/http_client_fail", decoder="xyz")
+	http_server.serve_content(json.dumps({
+		"Message": "Someone set us up the bomb"
+	}), 500)
+	
+	with pytest.raises(ipfshttpclient.exceptions.EncoderMissingError):
+		http_client.request("/http_client_fail", decoder="xyz")
 
-def test_failed_decoder(http_client):
+def test_failed_decoder(http_client, http_server):
 	"""Tests that a failed encoding parse raises an exception."""
-	with HTTMock(return_okay):
-		with pytest.raises(ipfshttpclient.exceptions.DecodingError):
-			http_client.request("/okay", decoder="json")
+	http_server.serve_content("okay", 200)
+	
+	with pytest.raises(ipfshttpclient.exceptions.DecodingError):
+		http_client.request("/okay", decoder="json")
 
 """TODO: Test successful download
 Need to determine correct way to mock an http request that returns a tar
@@ -213,33 +129,35 @@ file. tarfile.open expects the tar to be in the form of an octal escaped
 string, but internal functionality keeps resulting in hexadecimal.
 """
 
-def test_failed_download(http_client):
+def test_failed_download(http_client, http_server):
 	"""Tests that a failed download raises an HTTPError."""
-	with HTTMock(return_fail):
-		with pytest.raises(ipfshttpclient.exceptions.StatusError):
-			http_client.download("/fail")
+	http_server.serve_content("fail", 500)
+	
+	with pytest.raises(ipfshttpclient.exceptions.StatusError):
+		http_client.download("/fail")
 
-def test_session(http_client):
+def test_session(http_client, http_server):
 	"""Tests that a session is established and then closed."""
-	with HTTMock(return_okay):
-		with http_client.session():
-			res = http_client.request("/okay")
-			assert res == b"okay"
-		assert http_client._session is None
+	http_server.serve_content("okay", 200)
+	
+	with http_client.session():
+		res = http_client.request("/okay")
+		assert res == b"okay"
+	assert http_client._session is None
 
 
-def test_stream_close(mocker):
-	client = ipfshttpclient.http.HTTPClient("localhost", 5001, "api/v0")
+def test_stream_close(mocker, http_client, http_server):
 	mocker.patch("ipfshttpclient.http._notify_stream_iter_closed")
-	with HTTMock(return_okay):
-		with client.request("/okay", stream=True) as response_iter:
-			assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 0
-		assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 1
-
-		response_iter = client.request("/okay", stream=True)
-		assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 1
-		response_iter.close()
-		assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 2
-
-		client.request("/okay")
-		assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 3
+	http_server.serve_content("okay", 200)
+	
+	with http_client.request("/okay", stream=True) as response_iter:
+		assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 0
+	assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 1
+	
+	response_iter = http_client.request("/okay", stream=True)
+	assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 1
+	response_iter.close()
+	assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 2
+	
+	http_client.request("/okay")
+	assert ipfshttpclient.http._notify_stream_iter_closed.call_count == 3

--- a/test/unit/test_http.py
+++ b/test/unit/test_http.py
@@ -8,12 +8,9 @@ TestHttp -- A TCP client for interacting with an IPFS daemon
 """
 
 import json
-import tarfile
-import os
 
 from httmock import urlmatch, HTTMock
 import pytest
-import requests
 
 import ipfshttpclient.http
 import ipfshttpclient.exceptions

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -5,9 +5,7 @@ TestUtils -- defines a set of unit tests for untils.py
 """
 
 import io
-import json
-import os
-import pickle
+import os.path
 import unittest
 
 import ipfshttpclient.utils as utils


### PR DESCRIPTION
Follow-up of #169 using `pytest-localserver` instead of `httmock` for testing.