### PR TITLE
name tests and DHT-related arguments for publish

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -36,13 +36,31 @@ def sort_by_key(items, key="Name"):
 	return sorted(items, key=lambda x: x[key])
 
 
-
-@pytest.fixture
-def client():
+def get_client():
 	if is_available():
 		return ipfshttpclient.Client()
 	else:
 		pytest.skip("Running IPFS node required")
+
+
+@pytest.fixture(scope="function")
+def client():
+	"""Create a client with function lifetimme to connect to the IPFS daemon.
+
+	Each test function should instantiate a fresh client, so use this
+	fixture in test functions."""
+	return get_client()
+
+
+@pytest.fixture(scope="module")
+def module_client():
+	"""Create a client with a module lifetime to connect to the IPFS daemon.
+
+	For module-scope fixtures that need a client, if the client is to be created
+	automatically using a fixture (to keep client creation code centralized
+	here), that client-creating fixture must also be module-scope, so use
+	this fixture in module-scoped fixtures."""
+	return get_client()
 
 
 @pytest.fixture

--- a/test/functional/test_name.py
+++ b/test/functional/test_name.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-TIMEOUT = 240
+TIMEOUT = 300
 
 
 def get_key(client, key_name):
@@ -131,6 +131,6 @@ def test_resolve_recursive(client, published_mapping):
 
 def test_resolve_params(client, published_mapping):
 	resp = client.name.resolve(published_mapping.name,  nocache=True,
-	                           dht_record_count=1, dht_timeout="10s",
+	                           dht_record_count=1, dht_timeout="180s",
 	                           timeout=TIMEOUT)
 	check_resolve(resp, published_mapping.path)

--- a/test/functional/test_name.py
+++ b/test/functional/test_name.py
@@ -1,0 +1,128 @@
+# _*_ coding: utf-8 -*-
+
+import pytest
+
+
+def get_key(client, key_name):
+	keys = client.key.list()["Keys"]
+	for k in keys:
+		if k["Name"] == key_name:
+			return k
+	raise Exception("Unknown key: %s" % key_name)
+
+
+def hash_to_path(ns, h):
+	assert "/" not in h
+	assert h == h.strip()
+	return "/" + ns + "/" + h
+
+
+def hash_to_ipfs_path(h):
+	return hash_to_path("ipfs", h)
+
+
+def hash_to_ipns_path(h):
+	return hash_to_path("ipns", h)
+
+
+class Resources(object):
+	def __init__(self, client):
+		self.client = client
+
+
+	def __enter__(self):
+		self.key_self = get_key(self.client, "self")
+		self.key_test1 = self.client.key.gen("ipfshttpclient-test-name-1", "rsa")
+		self.key_test2 = self.client.key.gen("ipfshttpclient-test-name-2", "rsa")
+		self.msg1 = hash_to_ipfs_path(self.client.add_str("Mary had a little lamb"))
+		self.msg2 = hash_to_ipfs_path(self.client.add_str("Mary had a little alpaca"))
+		self.msg3 = hash_to_ipfs_path(self.client.add_str("Mary had a little goat"))
+		return self
+
+
+	def __exit__(self, t, v, tb):
+		self.client.pin.rm(self.msg1, self.msg2, self.msg3)
+		self.client.key.rm(self.key_test1["Name"], self.key_test2["Name"])
+
+
+class PublishedMapping(object):
+	def __init__(self, name, path):
+		self.name = name
+		self.path = path
+
+
+@pytest.fixture(scope="module")
+def resources(module_client):
+	with Resources(module_client) as resources:
+		yield resources
+
+
+@pytest.fixture(scope="module")
+def published_mapping(module_client, resources):
+	# we're not testing publish here, pass whatever args we want
+	resp = module_client.name.publish(resources.msg3,
+	                                  key=resources.key_test2["Name"],
+	                                  resolve=False, allow_offline=True,
+	                                  lifetime="5m", ttl="5m")
+	return PublishedMapping(resp["Name"], resp["Value"])
+
+
+def check_resolve(resp, path):
+	assert resp["Path"] == path
+
+
+def check_publish(client, response_path, resolved_path, key, resp):
+
+	name = resp["Name"]
+	assert name == key["Id"]
+	assert resp["Value"] == response_path
+
+	# we're not testing resolve here, pass whatever args we want
+	resolve_resp = client.name.resolve(name, recursive=True,
+	                                   dht_record_count=0, dht_timeout="1s")
+	check_resolve(resolve_resp, resolved_path)
+
+
+def test_publish_self(client, resources):
+	resp = client.name.publish(resources.msg1)
+	check_publish(client, resources.msg1, resources.msg1,
+	              resources.key_self, resp)
+
+
+def test_publish_params(client, resources):
+	resp = client.name.publish(resources.msg1, allow_offline=True,
+	                           lifetime="25h", ttl="1m")
+	check_publish(client, resources.msg1, resources.msg1,
+	              resources.key_self, resp)
+
+
+def test_publish_key(client, resources):
+	resp = client.name.publish(resources.msg2, key=resources.key_test1["Name"])
+	check_publish(client, resources.msg2, resources.msg2,
+	              resources.key_test1, resp)
+
+
+def test_publish_indirect(client, resources, published_mapping):
+	path = hash_to_ipns_path(published_mapping.name)
+	resp = client.name.publish(path, resolve=True)
+	check_publish(client, path, published_mapping.path,
+	              resources.key_self, resp)
+
+
+def test_resolve(client, published_mapping):
+	check_resolve(client.name.resolve(published_mapping.name), published_mapping.path)
+
+
+def test_resolve_recursive(client, published_mapping):
+	inner_path = hash_to_ipns_path(published_mapping.name)
+	res = client.name.publish(inner_path, resolve=False)
+	outer_path = res["Name"]
+
+	resp = client.name.resolve(outer_path, recursive=True)
+	check_resolve(resp, published_mapping.path)
+
+
+def test_resolve_params(client, published_mapping):
+	resp = client.name.resolve(published_mapping.name,  nocache=True,
+	                           dht_record_count=1, dht_timeout="10s",)
+	check_resolve(resp, published_mapping.path)


### PR DESCRIPTION
Tests take a long time to run. Would be nice if daemon supported offline mode; or at least support local resolve to resolve own keys instantly.