### PR TITLE
Offline mode

### DIFF
--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -216,7 +216,8 @@ class HTTPClient(object):
     @pass_defaults
     def request(self, path,
                 args=[], files=[], opts={}, stream=False,
-                decoder=None, headers={}, data=None, timeout=120):
+                decoder=None, headers={}, data=None,
+                timeout=120, offline=False):
         """Makes an HTTP request to the IPFS daemon.
 
         This function returns the contents of the HTTP response from the IPFS
@@ -247,6 +248,9 @@ class HTTPClient(object):
             before giving up
             
             Defaults to 120
+        offline : bool
+                Execute request in offline mode, i.e. locally without accessing
+                the network.
         kwargs : dict
             Additional arguments to pass to :mod:`requests`
         """
@@ -254,6 +258,8 @@ class HTTPClient(object):
 
         params = []
         params.append(('stream-channels', 'true'))
+        if offline:
+            params.append(('offline', 'true'))
         for opt in opts.items():
             params.append(opt)
         for arg in args:
@@ -268,7 +274,7 @@ class HTTPClient(object):
 
     @pass_defaults
     def download(self, path, args=[], filepath=None, opts={},
-                 compress=True, timeout=120, **kwargs):
+                 compress=True, timeout=120, offline=False, **kwargs):
         """Makes a request to the IPFS daemon to download a file.
 
         Downloads a file or files from IPFS into the current working
@@ -302,6 +308,9 @@ class HTTPClient(object):
             before giving up
             
             Defaults to 120
+        offline : bool
+                Execute request in offline mode, i.e. locally without accessing
+                the network.
         kwargs : dict
             Additional arguments to pass to :mod:`requests`
         """
@@ -310,6 +319,8 @@ class HTTPClient(object):
 
         params = []
         params.append(('stream-channels', 'true'))
+        if offline:
+            params.append(('offline', 'true'))
         params.append(('archive', 'true'))
         if compress:
             params.append(('compress', 'true'))

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -251,8 +251,6 @@ class HTTPClient(object):
         offline : bool
                 Execute request in offline mode, i.e. locally without accessing
                 the network.
-        kwargs : dict
-            Additional arguments to pass to :mod:`requests`
         """
         url = self.base + path
 

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -36,9 +36,9 @@ def sort_by_key(items, key="Name"):
 	return sorted(items, key=lambda x: x[key])
 
 
-def get_client():
+def get_client(offline=False):
 	if is_available():
-		return ipfshttpclient.Client()
+		return ipfshttpclient.Client(offline=offline)
 	else:
 		pytest.skip("Running IPFS node required")
 
@@ -52,6 +52,12 @@ def client():
 	return get_client()
 
 
+@pytest.fixture(scope="function")
+def offline_client():
+	"""Create a client in offline mode with function lifetimme"""
+	return get_client(offline=True)
+
+
 @pytest.fixture(scope="module")
 def module_client():
 	"""Create a client with a module lifetime to connect to the IPFS daemon.
@@ -61,6 +67,12 @@ def module_client():
 	here), that client-creating fixture must also be module-scope, so use
 	this fixture in module-scoped fixtures."""
 	return get_client()
+
+
+@pytest.fixture(scope="module")
+def module_offline_client():
+	"""Create a client in offline mode with module lifetime."""
+	return get_client(offline=True)
 
 
 @pytest.fixture

--- a/test/functional/test_name.py
+++ b/test/functional/test_name.py
@@ -65,9 +65,8 @@ def published_mapping(module_client, resources):
 	# we're not testing publish here, pass whatever args we want
 	resp = module_client.name.publish(resources.msg3,
 	                                  key=resources.key_test2["Name"],
-	                                  resolve=False, allow_offline=True,
-	                                  lifetime="5m", ttl="5m",
-	                                  timeout=TIMEOUT)
+	                                  resolve=False, lifetime="5m", ttl="5m",
+	                                  allow_offline=True, timeout=TIMEOUT)
 	return PublishedMapping(resp["Name"], resp["Value"])
 
 
@@ -89,28 +88,31 @@ def check_publish(client, response_path, resolved_path, key, resp):
 
 
 def test_publish_self(client, resources):
-	resp = client.name.publish(resources.msg1, timeout=TIMEOUT)
+	resp = client.name.publish(resources.msg1,
+	                           allow_offline=True, timeout=TIMEOUT)
 	check_publish(client, resources.msg1, resources.msg1,
 	              resources.key_self, resp)
 
 
 def test_publish_params(client, resources):
-	resp = client.name.publish(resources.msg1, allow_offline=True,
-	                           lifetime="25h", ttl="1m", timeout=TIMEOUT)
+	resp = client.name.publish(resources.msg1, lifetime="25h", ttl="1m",
+	                           allow_offline=True, timeout=TIMEOUT)
 	check_publish(client, resources.msg1, resources.msg1,
 	              resources.key_self, resp)
 
 
 def test_publish_key(client, resources):
 	resp = client.name.publish(resources.msg2,
-	                           key=resources.key_test1["Name"], timeout=TIMEOUT)
+	                           key=resources.key_test1["Name"],
+	                           allow_offline=True, timeout=TIMEOUT)
 	check_publish(client, resources.msg2, resources.msg2,
 	              resources.key_test1, resp)
 
 
 def test_publish_indirect(client, resources, published_mapping):
 	path = hash_to_ipns_path(published_mapping.name)
-	resp = client.name.publish(path, resolve=True, timeout=TIMEOUT)
+	resp = client.name.publish(path, resolve=True,
+	                           allow_offline=True, timeout=TIMEOUT)
 	check_publish(client, path, published_mapping.path,
 	              resources.key_self, resp)
 
@@ -122,7 +124,8 @@ def test_resolve(client, published_mapping):
 
 def test_resolve_recursive(client, published_mapping):
 	inner_path = hash_to_ipns_path(published_mapping.name)
-	res = client.name.publish(inner_path, resolve=False, timeout=TIMEOUT)
+	res = client.name.publish(inner_path, resolve=False,
+	                          allow_offline=True, timeout=TIMEOUT)
 	outer_path = res["Name"]
 
 	resp = client.name.resolve(outer_path, recursive=True, timeout=TIMEOUT)

--- a/test/functional/test_name.py
+++ b/test/functional/test_name.py
@@ -3,9 +3,6 @@
 import pytest
 
 
-TIMEOUT = 300
-
-
 def get_key(client, key_name):
 	keys = client.key.list()["Keys"]
 	for k in keys:
@@ -29,8 +26,8 @@ def hash_to_ipns_path(h):
 
 
 class Resources(object):
-	def __init__(self, client):
-		self.client = client
+	def __init__(self, offline_client):
+		self.client = offline_client
 
 
 	def __enter__(self):
@@ -55,18 +52,18 @@ class PublishedMapping(object):
 
 
 @pytest.fixture(scope="module")
-def resources(module_client):
-	with Resources(module_client) as resources:
+def resources(module_offline_client):
+	with Resources(module_offline_client) as resources:
 		yield resources
 
 
 @pytest.fixture(scope="module")
-def published_mapping(module_client, resources):
+def published_mapping(module_offline_client, resources):
 	# we're not testing publish here, pass whatever args we want
-	resp = module_client.name.publish(resources.msg3,
-	                                  key=resources.key_test2["Name"],
-	                                  resolve=False, lifetime="5m", ttl="5m",
-	                                  allow_offline=True, timeout=TIMEOUT)
+	resp = module_offline_client.name.publish(
+		resources.msg3,
+		key=resources.key_test2["Name"], resolve=False,
+		lifetime="5m", ttl="5m", allow_offline=True)
 	return PublishedMapping(resp["Name"], resp["Value"])
 
 
@@ -74,66 +71,68 @@ def check_resolve(resp, path):
 	assert resp["Path"] == path
 
 
-def check_publish(client, response_path, resolved_path, key, resp):
+def check_publish(offline_client, response_path, resolved_path, key, resp):
 
 	name = resp["Name"]
 	assert name == key["Id"]
 	assert resp["Value"] == response_path
 
 	# we're not testing resolve here, pass whatever args we want
-	resolve_resp = client.name.resolve(name, recursive=True,
-	                                   dht_record_count=0, dht_timeout="1s",
-	                                   timeout=TIMEOUT)
+	resolve_resp = offline_client.name.resolve(
+		name,
+		recursive=True, dht_record_count=0, dht_timeout="1s",
+		offline=True)
 	check_resolve(resolve_resp, resolved_path)
 
 
-def test_publish_self(client, resources):
-	resp = client.name.publish(resources.msg1,
-	                           allow_offline=True, timeout=TIMEOUT)
-	check_publish(client, resources.msg1, resources.msg1,
+def test_publish_self(offline_client, resources):
+	resp = offline_client.name.publish(resources.msg1, allow_offline=True)
+	check_publish(offline_client, resources.msg1, resources.msg1,
 	              resources.key_self, resp)
 
 
-def test_publish_params(client, resources):
-	resp = client.name.publish(resources.msg1, lifetime="25h", ttl="1m",
-	                           allow_offline=True, timeout=TIMEOUT)
-	check_publish(client, resources.msg1, resources.msg1,
+def test_publish_params(offline_client, resources):
+	resp = offline_client.name.publish(resources.msg1,
+	                                   lifetime="25h", ttl="1m",
+	                                   allow_offline=True)
+	check_publish(offline_client, resources.msg1, resources.msg1,
 	              resources.key_self, resp)
 
 
-def test_publish_key(client, resources):
-	resp = client.name.publish(resources.msg2,
-	                           key=resources.key_test1["Name"],
-	                           allow_offline=True, timeout=TIMEOUT)
-	check_publish(client, resources.msg2, resources.msg2,
+def test_publish_key(offline_client, resources):
+	resp = offline_client.name.publish(
+		resources.msg2,
+		key=resources.key_test1["Name"], allow_offline=True)
+	check_publish(offline_client, resources.msg2, resources.msg2,
 	              resources.key_test1, resp)
 
 
-def test_publish_indirect(client, resources, published_mapping):
+def test_publish_indirect(offline_client, resources, published_mapping):
 	path = hash_to_ipns_path(published_mapping.name)
-	resp = client.name.publish(path, resolve=True,
-	                           allow_offline=True, timeout=TIMEOUT)
-	check_publish(client, path, published_mapping.path,
+	resp = offline_client.name.publish(path,
+	                                   resolve=True, allow_offline=True)
+	check_publish(offline_client, path, published_mapping.path,
 	              resources.key_self, resp)
 
 
-def test_resolve(client, published_mapping):
-	check_resolve(client.name.resolve(published_mapping.name, timeout=TIMEOUT),
+def test_resolve(offline_client, published_mapping):
+	check_resolve(offline_client.name.resolve(published_mapping.name),
 	              published_mapping.path)
 
 
-def test_resolve_recursive(client, published_mapping):
+def test_resolve_recursive(offline_client, published_mapping):
 	inner_path = hash_to_ipns_path(published_mapping.name)
-	res = client.name.publish(inner_path, resolve=False,
-	                          allow_offline=True, timeout=TIMEOUT)
+	res = offline_client.name.publish(inner_path,
+	                                  resolve=False, allow_offline=True)
 	outer_path = res["Name"]
 
-	resp = client.name.resolve(outer_path, recursive=True, timeout=TIMEOUT)
+	resp = offline_client.name.resolve(outer_path, recursive=True)
 	check_resolve(resp, published_mapping.path)
 
 
-def test_resolve_params(client, published_mapping):
-	resp = client.name.resolve(published_mapping.name,  nocache=True,
-	                           dht_record_count=1, dht_timeout="180s",
-	                           timeout=TIMEOUT)
+def test_resolve_params(offline_client, published_mapping):
+	resp = offline_client.name.resolve(
+		published_mapping.name,
+		nocache=True, dht_record_count=1, dht_timeout="180s",
+		offline=True)
 	check_resolve(resp, published_mapping.path)


### PR DESCRIPTION
My earlier prayer has been answered incredibly fast: go-ipfs 0.4.19 added an offline flag. Oh if only I had this yesterday... would have saved me hours. Now name tests run within a few seconds instead of tens of minutes!

I also tried launching the whole daemon with `--offline` but the bitswap and pubsub tests require online mode. Regardless of testing, though, the API should support offline at the granularity of connection and request, which this PR adds.

f96aaee is not strictly necessary, but it fixes the test hang when run with `--offline` daemon.

d43208d is unrelated. I just noticed the kwargs in the docs, but it was not in the code. It looked harmless and useful to add it, but if not, I can remove this commit from this PR.