### PR TITLE
files.cp: fix return attribute in cp to be void

### DIFF
--- a/ipfshttpclient/client/files.py
+++ b/ipfshttpclient/client/files.py
@@ -12,7 +12,7 @@ class Section(base.SectionBase):
 	file storage space.
 	"""
 	
-	@base.returns_single_item
+	@base.returns_no_item
 	def cp(self, source, dest, **kwargs):
 		"""Copies files within the MFS.
 

--- a/test/functional/test_files.py
+++ b/test/functional/test_files.py
@@ -297,6 +297,18 @@ TEST_MFS_FILES = {
 TEST_MFS_DIRECTORY = "/test_dir"
 
 
+def test_mfs_file_cp_rm(client, cleanup_pins):
+	res = client.add(FAKE_FILE1_PATH)
+	h = res["Hash"]
+
+	mfs_path = "/" + TEST_MFS_DIRECTORY + "file1"
+	res = client.files.cp("/ipfs/" + h, mfs_path)
+	assert res is None
+
+	res = client.files.rm(mfs_path)
+	assert res is None
+
+
 def test_mfs_file_write_stat_read_delete(client):
 	for filename, desc in TEST_MFS_FILES.items():
 		filepath = "/" + filename


### PR DESCRIPTION
Fixes assert failure introduced in 52df768c.
Added test that would have caught the problem.

```
AssertionError: Called IPFS HTTP-Client function should only ever return a list, when not streaming a response
```