### PR TITLE
Fixes inconsistent encoding behavior.

### DIFF
--- a/ipfsapi/encoding.py
+++ b/ipfsapi/encoding.py
@@ -278,7 +278,7 @@ class Json(Encoding):
         """
         try:
             result = json.dumps(obj, sort_keys=True, indent=None,
-                                separators=(',', ':'))
+                                separators=(',', ':'), ensure_ascii=False)
             if isinstance(result, six.text_type):
                 return result.encode("utf-8")
             else:


### PR DESCRIPTION
Python encodes ASCII by default and escapes the unicode characters.
This fix enforces utf-8.


```
Python 3.5.2 (default, Nov 23 2017, 16:37:01) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ipfsapi
>>> api = ipfsapi.connect('127.0.0.1', 5001)
>>> val = {"key": "Value, não é?"}
>>> api.add_json(val)
'QmNRzhk1e4cHYpqej7LjguBd5fP4uLyVYTQFfJFGm9ESLQ'
>>> api.get_json('QmNRzhk1e4cHYpqej7LjguBd5fP4uLyVYTQFfJFGm9ESLQ')
{'key': 'Value, não é?'}
>>> 
```
This is ok, expected behavior.

https://ipfs.io/ipfs/QmNRzhk1e4cHYpqej7LjguBd5fP4uLyVYTQFfJFGm9ESLQ <-- Ok here as well.