### PR TITLE
Fix `urllib3`'s loading of the system CA bundle on 1.25+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Python IPFS HTTP Client Library](https://ipfs.io/ipfs/QmQJ68PFMDdAsgCZvA1UVzzn18asVcf7HVvCDgpjiSCAse)
 
-Check out [the HTTP Client reference](https://ipfs.io/ipns/QmZ86ow1byeyhNRJEatWxGPJKcnQKG7s51MtbHdxxUddTH/Software/Python/ipfshttpclient/) for the full command reference.
+Check out [the HTTP Client reference](https://ipfs.io/ipns/12D3KooWEqnTdgqHnkkwarSrJjeMP2ZJiADWLYADaNvUb6SQNyPF/docs/) for the full command reference.
 
 **Important:** The `ipfsapi` PIP package and Python module have both been renamed to `ipfshttpclient`!
 See the [relevant section of the README](#important-changes-from-ipfsapi-04x) for details.
@@ -142,7 +142,7 @@ This module also contains some helper functions for adding strings and JSON to I
 
 Documentation (currently mostly API documentation unfortunately) is available on IPFS:
 
-https://ipfs.io/ipns/QmZ86ow1byeyhNRJEatWxGPJKcnQKG7s51MtbHdxxUddTH/Software/Python/ipfsapi/
+https://ipfs.io/ipns/12D3KooWEqnTdgqHnkkwarSrJjeMP2ZJiADWLYADaNvUb6SQNyPF/docs/
 
 The `ipfs` [command-line Client documentation](https://ipfs.io/docs/commands/) may also be useful in some cases.
 

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -10,6 +10,7 @@ import abc
 import functools
 import tarfile
 from six.moves import http_client
+import os
 import socket
 try:  #PY3
 	import urllib.parse
@@ -23,7 +24,12 @@ import six
 
 from . import encoding
 from . import exceptions
-from . import requests_wrapper as requests
+PATCH_REQUESTS = (os.environ.get("PY_IPFS_HTTP_CLIENT_PATCH_REQUESTS", "yes").lower()
+                  not in ("false", "no"))
+if PATCH_REQUESTS:
+	from . import requests_wrapper as requests
+else:  # pragma: no cover (always enabled in production)
+	import requests
 
 
 def pass_defaults(func):
@@ -210,9 +216,9 @@ class HTTPClient(object):
 			query    = "",
 			fragment = ""
 		).geturl()
-		self._kwargs = {
-			"family": family
-		}
+		self._kwargs = {}
+		if PATCH_REQUESTS:  # pragma: no branch (always enabled in production)
+			self._kwargs["family"] = family
 		
 		self.defaults = defaults
 		self._session = None

--- a/ipfshttpclient/version.py
+++ b/ipfshttpclient/version.py
@@ -8,4 +8,4 @@
 # `0.4.1` and so on. When IPFS `0.5.0` is released, the first client version
 # to support it will also be released as `0.5.0`.
 
-__version__ = "0.4.11"
+__version__ = "0.4.12"

--- a/renaming_status.txt
+++ b/renaming_status.txt
@@ -23,7 +23,7 @@ FOR README.md:
     https://travis-ci.org/ipfs/py-ipfs-api.svg?branch=master -> https://travis-ci.org/ipfs/py-ipfs-http-client.svg?branch=master        line 7
     https://travis-ci.org/ipfs/py-ipfs-api -> https://travis-ci.org/ipfs/py-ipfs-http-client                                            line 7
     https://ipfs.io/ipns/QmZ86ow1byeyhNRJEatWxGPJKcnQKG7s51MtbHdxxUddTH/Software/Python/ipfsapi/ ->
-                    https://ipfs.io/ipns/QmZ86ow1byeyhNRJEatWxGPJKcnQKG7s51MtbHdxxUddTH/Software/Python/ipfshttpclient/                 line 11,118
+                    https://ipfs.io/ipns/12D3KooWEqnTdgqHnkkwarSrJjeMP2ZJiADWLYADaNvUb6SQNyPF/docs/                 line 11,118
     The PIP package and Python module: ipfshttpclient
     The Github repo: py-ipfs-api -> py-ipfs-http-client
     PROJECT RENAME:        Python IPFS API -> Python IPFS HTTP Client
@@ -50,7 +50,7 @@ FOR pyproject.toml:
 * Changes:  module = "ipfsapi" -> module = "ipfshttpclient"             Line 6
             py-ipfs-api -> py-ipfs-http-client
             https://ipfs.io/ipns/QmZ86ow1byeyhNRJEatWxGPJKcnQKG7s51MtbHdxxUddTH/Software/Python/ipfsapi/ ->
-                    https://ipfs.io/ipns/QmZ86ow1byeyhNRJEatWxGPJKcnQKG7s51MtbHdxxUddTH/Software/Python/ipfshttpclient/
+                    https://ipfs.io/ipns/12D3KooWEqnTdgqHnkkwarSrJjeMP2ZJiADWLYADaNvUb6SQNyPF/docs/
 * Doubtful: Line 3
 
 


### PR DESCRIPTION
Fixes #184, details from commit message:

> Fix issues in the requests wrapper with `urllib3` 1.21.* and 1.25.*
>
> For older `urllib3` versions an attribute we assumed to be present was not,
causing a crash.
> 
> For the latest version inheriting our patched `HTTPSConnectionPool` class from
the wrong base class `urllib3.HTTPConnectionPool` (rather than
`urllib3.HTTPSConnectionPool`) caused HTTPS validation to mysteriously fail,
as the system CA store wasn't loaded anymore.

Additionally it includes a new environment variable that can be used to temporarily disable loading of the requests wrapper/patcher.