### PR TITLE
Add interface for the remote pinning API

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -36,6 +36,7 @@ from . import miscellaneous
 from . import name
 from . import object
 from . import pin
+from . import pinremote
 from . import pubsub
 from . import repo
 #TODO: `from . import stats`
@@ -186,6 +187,7 @@ class Client(files.Base, miscellaneous.Base):
 	name      = base.SectionProperty(name.Section)
 	object    = base.SectionProperty(object.Section)
 	pin       = base.SectionProperty(pin.Section)
+	pinremote = base.SectionProperty(pinremote.Section)
 	pubsub    = base.SectionProperty(pubsub.Section)
 	repo      = base.SectionProperty(repo.Section)
 	swarm     = base.SectionProperty(swarm.Section)

--- a/ipfshttpclient/client/pinremote.py
+++ b/ipfshttpclient/client/pinremote.py
@@ -1,0 +1,81 @@
+from . import base
+
+
+class Section(base.SectionBase):
+    def service_add(self, service: str, endpoint: str,
+                    key: str,
+                    **kwargs: base.CommonArgs):
+        args = (service, endpoint, key)
+        return self._client.request('/pin/remote/service/add',
+                                    args, **kwargs)
+
+    @base.returns_single_item(base.ResponseBase)
+    def service_ls(self, stat: bool = False, **kwargs: base.CommonArgs):
+        kwargs.setdefault('opts', {'stat': stat})
+
+        return self._client.request('/pin/remote/service/ls', (),
+                                    decoder='json', **kwargs)
+
+    def service_rm(self, service: str, **kwargs: base.CommonArgs):
+        args = (service,)
+        return self._client.request('/pin/remote/service/rm', args, **kwargs)
+
+    @base.returns_single_item(base.ResponseBase)
+    def add(self, service: str, path: base.cid_t,
+            name: str = None, background = False,
+            **kwargs: base.CommonArgs):
+        opts = {
+            'service': service,
+            'arg': path,
+            'background': background
+        }
+        if name:
+            opts['name'] = name
+
+        kwargs.setdefault('opts', opts)
+
+        return self._client.request('/pin/remote/add', (),
+                                    decoder='json', **kwargs)
+
+    @base.returns_multiple_items(base.ResponseBase)
+    def ls(self, service: str,
+           name: str = None, cid: list = [],
+           status: list = ['pinned'],
+            **kwargs: base.CommonArgs):
+        opts = {
+            'service': service,
+            'status': status
+        }
+
+        if len(cid) > 0:
+            opts['cid'] = cid
+
+        if name:
+            opts['name'] = name
+
+        kwargs.setdefault('opts', opts)
+
+        return self._client.request('/pin/remote/ls', (),
+                                    decoder='json', **kwargs)
+
+    def rm(self, service: str,
+           name: str = None, cid: list = [],
+           status: list = ['pinned'],
+           force: bool = False,
+            **kwargs: base.CommonArgs):
+        opts = {
+            'service': service,
+            'cid': cid,
+            'status': status,
+            'force': force
+        }
+
+        if len(cid) > 0:
+            opts['cid'] = cid
+
+        if name is not None:
+            opts['name'] = name
+
+        kwargs.setdefault('opts', opts)
+
+        return self._client.request('/pin/remote/rm', (), **kwargs)

--- a/ipfshttpclient/version.py
+++ b/ipfshttpclient/version.py
@@ -8,4 +8,4 @@
 # `0.4.1` and so on. When IPFS `0.5.0` is released, the first client version
 # to support it will also be released as `0.5.0`.
 
-__version__ = "0.8.0a2"
+__version__ = "0.8.0a3"


### PR DESCRIPTION
This adds the necessary functions to support the remote pinning API introduced in go-ipfs v0.8.0. Tested it with [iraty](https://gitlab.com/cipres/iraty) and it works as expected with go-ipfs 0.9.0 but it needs a review .. Docs (docstrings) not included yet.